### PR TITLE
Implement htlcc swap with additional secrets

### DIFF
--- a/packages/bitcoin-collateral-swap-provider/lib/BitcoinCollateralSwapProvider.js
+++ b/packages/bitcoin-collateral-swap-provider/lib/BitcoinCollateralSwapProvider.js
@@ -1,545 +1,494 @@
+import * as bitcoin from 'bitcoinjs-lib'
 import Provider from '@atomicloans/provider'
+import { addressToString, sleep } from '@liquality/utils'
 import networks from '@liquality/bitcoin-networks'
-
 import {
-  calculateFee,
-  addressToPubKeyHash,
-  pubKeyToAddress,
-  pubKeyHashToAddress,
-  reverseBuffer,
-  scriptNumEncode
+  calculateFee
 } from '@liquality/bitcoin-utils'
 import {
   hash160,
-  sha256,
-  padHexStart
+  sha256
 } from '@liquality/crypto'
-import { sleep } from '@liquality/utils'
 
 import { version } from '../package.json'
 
+const OPS = bitcoin.script.OPS
+
 export default class BitcoinCollateralSwapProvider extends Provider {
-  constructor (chain = { network: networks.bitcoin }) {
+ constructor (chain = { network: networks.bitcoin }, mode = { script: 'p2sh_p2wsh', address: 'p2sh_p2wpkh' }) {
     super()
     this._network = chain.network
+    if (!['p2wsh', 'p2sh_p2wsh', 'p2sh'].includes(mode.script)) {
+      throw new Error('Mode must be one of p2wsh, p2sh_p2wsh, p2sh')
+    }
+    if (!['p2wpkh', 'p2sh_p2wpkh', 'p2pkh'].includes(mode.address)) {
+      throw new Error('Mode must be one of p2wpkh, p2sh_p2wpkh, p2pkh')
+    }
+    this._mode = mode
+    if (this._network.name === networks.bitcoin.name) {
+      this._bitcoinJsNetwork = bitcoin.networks.mainnet
+    } else if (this._network.name === networks.bitcoin_testnet.name) {
+      this._bitcoinJsNetwork = bitcoin.networks.testnet
+    } else if (this._network.name === networks.bitcoin_regtest.name) {
+      this._bitcoinJsNetwork = bitcoin.networks.regtest
+    }
   }
 
-  createRefundableScript (borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashD1, loanExpiration, biddingExpiration) {
-    let loanExpirationHex = scriptNumEncode(loanExpiration)
-    let biddingExpirationHex = scriptNumEncode(biddingExpiration)
-
-    const borrowerPubKeyHash = hash160(borrowerPubKey)
-    const borrowerPubKeyPushDataOpcode = padHexStart((borrowerPubKey.length / 2).toString(16))
-
-    const lenderPubKeyPushDataOpcode = padHexStart((lenderPubKey.length / 2).toString(16))
-
-    const agentPubKeyPushDataOpcode = padHexStart((agentPubKey.length / 2).toString(16))
-
-    const loanExpirationPushDataOpcode = padHexStart(loanExpirationHex.length.toString(16))
-    const loanExpirationHexEncoded = loanExpirationHex.toString('hex')
-    const biddingExpirationPushDataOpcode = padHexStart(biddingExpirationHex.length.toString(16))
-    const biddingExpirationHexEncoded = biddingExpirationHex.toString('hex')
-
-    return [
-      '63', // OP_IF
-        '82', // OP_SIZE
-        '01', // OP_PUSHDATA(1)
-        '20', // Hex 32
-        '88', // OP_EQUALVERIFY
-        'a8', // OP_SHA256
-        '20', secretHashD1, // OP_PUSHDATA(20) {secretHash}
-        '88', // OP_EQUALVERIFY
-        '76', // OP_DUP
-        'a9', // OP_HASH160
-        '14', bidderPubKeyHash, // OP_PUSHDATA(20) {recipientPubKeyHash}
-        '88', 'ac', // OP_EQUALVERIFY OP_CHECKSIG
-      '67', // OP_ELSE
-        '63', // OP_IF
-          loanExpirationPushDataOpcode, // OP_PUSHDATA({loanExpirationHexLength})
-          loanExpirationHexEncoded, // {loanExpirationHexEncoded}
-          'b1', // OP_CHECKLOCKTIMEVERIFY
-          '75', // OP_DROP
-          '52', // PUSH #2
-          borrowerPubKeyPushDataOpcode, borrowerPubKey, // OP_PUSHDATA({alicePubKeyLength}) {alicePubKey}
-          lenderPubKeyPushDataOpcode, lenderPubKey, // OP_PUSHDATA({bobPubKeyLength}) {bobPubKey}
-          agentPubKeyPushDataOpcode, agentPubKey, // OP_PUSHDATA({agentPubKeyLength}) {agentPubKey}
-          '53', // PUSH #3
-          'ae', // CHECKMULTISIG
-        '67', // OP_ELSE
-          biddingExpirationPushDataOpcode, // OP_PUSHDATA({biddingExpirationHexLength})
-          biddingExpirationHexEncoded, // {biddingExpirationHexEncoded}
-          'b1', // OP_CHECKLOCKTIMEVERIFY
-          '75', // OP_DROP
-          '76', 'a9', // OP_DUP OP_HASH160
-          '14', borrowerPubKeyHash, // OP_PUSHDATA(20) {alicePubKeyHash}
-          '88', 'ac', // OP_EQUALVERIFY OP_CHECKSIG
-        '68', // OP_ENDIF
-      '68' // OP_ENDIF
-    ].join('')
+  getPubKeyHash (address) {
+    // TODO: wrapped segwit addresses not supported. Not possible to derive pubkeyHash from address
+    try {
+      const bech32 = bitcoin.address.fromBech32(address)
+      return bech32.data
+    } catch (e) {
+      const base58 = bitcoin.address.fromBase58Check(address)
+      return base58.hash
+    }
   }
 
-  createSeizableScript (borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration) {
-    let loanExpirationHex = scriptNumEncode(loanExpiration)
-    let biddingExpirationHex = scriptNumEncode(biddingExpiration)
-    let seizureExpirationHex = scriptNumEncode(seizureExpiration)
+  pubKeyToAddress (pubkey) {
+    const network = this._bitcoinJsNetwork
+    if (this._mode.address === 'p2pkh') {
+      return (bitcoin.payments.p2pkh({ pubkey, network })).address
+    } else if (this._mode.address === 'p2sh_p2wpkh') {
+      return (bitcoin.payments.p2sh({ redeem: bitcoin.payments.p2wpkh({ pubkey, network }), network })).address
+    } else if (this._mode.address === 'p2wpkh') {
+      return (bitcoin.payments.p2wpkh({ pubkey, network })).address
+    }
+  }
+
+  getCollateralOutput (pubKeys, secretHashes, expirations, seizable) {
+    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { secretHashA1 }                              = secretHashes
+    const { secretHashB1 }                              = secretHashes
+    const { secretHashC1 }                              = secretHashes
+    const { secretHashD1 }                              = secretHashes
+    const { swapExpiration, biddingExpiration }         = expirations
 
     const borrowerPubKeyHash = hash160(borrowerPubKey)
-    const borrowerPubKeyPushDataOpcode = padHexStart((borrowerPubKey.length / 2).toString(16))
-
     const lenderPubKeyHash = hash160(lenderPubKey)
-    const lenderPubKeyPushDataOpcode = padHexStart((lenderPubKey.length / 2).toString(16))
 
-    const agentPubKeyPushDataOpcode = padHexStart((agentPubKey.length / 2).toString(16))
+    const seizablePubKeyHash = seizable ? lenderPubKeyHash : borrowerPubKeyHash
 
-    const loanExpirationPushDataOpcode = padHexStart(loanExpirationHex.length.toString(16))
-    const loanExpirationHexEncoded = loanExpirationHex.toString('hex')
-    const biddingExpirationPushDataOpcode = padHexStart(biddingExpirationHex.length.toString(16))
-    const biddingExpirationHexEncoded = biddingExpirationHex.toString('hex')
-    const seizureExpirationPushDataOpcode = padHexStart(seizureExpirationHex.length.toString(16))
-    const seizureExpirationHexEncoded = seizureExpirationHex.toString('hex')
-
-    return [
-      '63', // OP_IF
-        '82', // OP_SIZE
-        '01', // OP_PUSHDATA(1)
-        '20', // Hex 32
-        '88', // OP_EQUALVERIFY
-        'a8', // OP_SHA256
-        '20', secretHashD1, // OP_PUSHDATA(20) {secretHash}
-        '88', // OP_EQUALVERIFY
-        '76', // OP_DUP
-        'a9', // OP_HASH160
-        '14', bidderPubKeyHash, // OP_PUSHDATA(20) {recipientPubKeyHash}
-        '88', 'ac', // OP_EQUALVERIFY OP_CHECKSIG
-      '67', // OP_ELSE
-        '63', // OP_IF
-          loanExpirationPushDataOpcode, // OP_PUSHDATA({loanExpirationHexLength})
-          loanExpirationHexEncoded, // {loanExpirationHexEncoded}
-          'b1', // OP_CHECKLOCKTIMEVERIFY
-          '75', // OP_DROP
-          '52', // PUSH #2
-          borrowerPubKeyPushDataOpcode, borrowerPubKey, // OP_PUSHDATA({alicePubKeyLength}) {alicePubKey}
-          lenderPubKeyPushDataOpcode, lenderPubKey, // OP_PUSHDATA({bobPubKeyLength}) {bobPubKey}
-          agentPubKeyPushDataOpcode, agentPubKey, // OP_PUSHDATA({agentPubKeyLength}) {agentPubKey}
-          '53', // PUSH #3
-          'ae', // CHECKMULTISIG
-        '67', // OP_ELSE
-          '63', // OP_IF
-            biddingExpirationPushDataOpcode, // OP_PUSHDATA({expirationHexLength})
-            biddingExpirationHexEncoded, // {expirationHexEncoded}
-            'b1', // OP_CHECKLOCKTIMEVERIFY
-            '75', // OP_DROP
-            '82', // OP_SIZE
-            '01', // OP_PUSHDATA(1)
-            '20', // Hex 32
-            '88', // OP_EQUALVERIFY
-            'a8', // OP_SHA256
-            '20', secretHashA1, // OP_PUSHDATA(32) {secretHashA1}
-            '88', // OP_EQUALVERIFY
-            '76', 'a9', // OP_DUP OP_HASH160
-            '14', lenderPubKeyHash, // OP_PUSHDATA(20) {bobPubKeyHash}
-            '88', 'ac', // OP_EQUALVERIFY OP_CHECKSIG
-            '67', // OP_ELSE
-            seizureExpirationPushDataOpcode, // OP_PUSHDATA({seizureExpirationHexLength})
-            seizureExpirationHexEncoded, // {seizureExpirationHexEncoded}
-            'b1', // OP_CHECKLOCKTIMEVERIFY
-            '75', // OP_DROP
-            '76', 'a9', // OP_DUP OP_HASH160
-            '14', borrowerPubKeyHash, // OP_PUSHDATA(20) {alicePubKeyHash}
-            '88', 'ac', // OP_EQUALVERIFY OP_CHECKSIG
-          '68', // OP_ENDIF
-        '68', // OP_ENDIF
-      '68' // OP_ENDIF
-    ].join('')
+    return bitcoin.script.compile([
+      OPS.OP_IF,
+        OPS.OP_SIZE,
+        bitcoin.script.number.encode(32),
+        OPS.OP_EQUAL,
+        OPS.OP_SWAP,
+        OPS.OP_SHA256,
+        Buffer.from(secretHashA1, 'hex'),
+        OPS.OP_EQUAL,
+        OPS.OP_ADD,
+        OPS.OP_2,
+        OPS.OP_EQUAL,
+        OPS.OP_SWAP,
+        OPS.OP_SIZE,
+        bitcoin.script.number.encode(32),
+        OPS.OP_EQUAL,
+        OPS.OP_SWAP,
+        OPS.OP_SHA256,
+        Buffer.from(secretHashB1, 'hex'),
+        OPS.OP_EQUAL,
+        OPS.OP_ADD,
+        OPS.OP_2,
+        OPS.OP_EQUAL,
+        OPS.OP_ADD,
+        OPS.OP_SWAP,
+        OPS.OP_SIZE,
+        bitcoin.script.number.encode(32),
+        OPS.OP_EQUAL,
+        OPS.OP_SWAP,
+        OPS.OP_SHA256,
+        Buffer.from(secretHashC1, 'hex'),
+        OPS.OP_EQUAL,
+        OPS.OP_ADD,
+        OPS.OP_2,
+        OPS.OP_EQUAL,
+        OPS.OP_ADD,
+        OPS.OP_2,
+        OPS.OP_GREATERTHANOREQUAL,
+        OPS.OP_VERIFY,
+        OPS.OP_SIZE,
+        bitcoin.script.number.encode(32),
+        OPS.OP_EQUALVERIFY,
+        OPS.OP_SHA256,
+        Buffer.from(secretHashD1, 'hex'),
+        OPS.OP_EQUALVERIFY,
+        OPS.OP_DUP,
+        OPS.OP_HASH160,
+        Buffer.from(borrowerPubKeyHash, 'hex'),
+        OPS.OP_EQUALVERIFY,
+        OPS.OP_CHECKSIG,
+      OPS.OP_ELSE,
+        OPS.OP_IF,
+          bitcoin.script.number.encode(swapExpiration),
+          OPS.OP_CHECKLOCKTIMEVERIFY,
+          OPS.OP_DROP,
+          OPS.OP_2,
+          Buffer.from(borrowerPubKey, 'hex'),
+          Buffer.from(lenderPubKey, 'hex'),
+          Buffer.from(agentPubKey, 'hex'),
+          OPS.OP_3,
+          OPS.OP_CHECKMULTISIG,
+        OPS.OP_ELSE,
+          bitcoin.script.number.encode(biddingExpiration),
+          OPS.OP_CHECKLOCKTIMEVERIFY,
+          OPS.OP_DROP,
+          OPS.OP_DUP,
+          OPS.OP_HASH160,
+          Buffer.from(seizablePubKeyHash, 'hex'),
+          OPS.OP_EQUALVERIFY,
+          OPS.OP_CHECKSIG,
+        OPS.OP_ENDIF,
+      OPS.OP_ENDIF
+    ])
   }
 
-  async lock (refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration) {    
-    const refundableScript = this.createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashD1, loanExpiration, biddingExpiration)
-    const seizableScript = this.createSeizableScript(borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration)
+  getCollateralInput (sigs, period, secrets, pubKey) {
+    if (!Array.isArray(sigs)) { sigs = [sigs]}
 
-    const refundableScriptPubKey = padHexStart(refundableScript)
-    const seizableScriptPubKey = padHexStart(seizableScript)
-
-    const refundableP2shAddress = pubKeyToAddress(refundableScriptPubKey, this._network.name, 'scriptHash')
-    const seizableP2shAddress = pubKeyToAddress(seizableScriptPubKey, this._network.name, 'scriptHash')
-
-    const refundableResult = await this.getMethod('sendTransaction')(refundableP2shAddress, refundableValue, refundableScript)
-    const seizableResult = await this.getMethod('sendTransaction')(seizableP2shAddress, seizableValue, seizableScript)
-
-    return { refundableResult, seizableResult }
-  }
-
-  async refund (refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, secretHashA1, secretD1, loanExpiration, biddingExpiration, seizureExpiration) {
-    const secretHashD1 = sha256(secretD1)
-    const bidderPubKeyHash = hash160(bidderPubKey)
-
-    const refundableScript = this.createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashD1, loanExpiration, biddingExpiration)
-    const seizableScript = this.createSeizableScript(borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration)
-
-    const refundableResult = await this._refund(refundableTxHash, refundableScript, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, secretHashA1, secretD1, loanExpiration, biddingExpiration, seizureExpiration, false, 'loanPeriod')
-    const seizableResult = await this._refund(seizableTxHash, seizableScript, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, secretHashA1, secretD1, loanExpiration, biddingExpiration, seizureExpiration, true, 'loanPeriod')
-
-    return { refundableResult, seizableResult }
-  }
-
-  async seize (seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    const secretHashA1 = sha256(secretA1)
-
-    const seizableScript = this.createSeizableScript(borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration)
-
-    return this._refund(seizableTxHash, seizableScript, borrowerPubKey, lenderPubKey, secretA1, secretHashB1, secretHashC1, loanExpiration, biddingExpiration, seizureExpiration, true, 'seizurePeriod')
-  }
-
-  async refundRefundable (refundableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    const refundableScript = this.createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration)
-
-    return this._refund(refundableTxHash, refundableScript, borrowerPubKey, lenderPubKey, secretHashA1, secretHashB1, secretHashC1, loanExpiration, biddingExpiration, seizureExpiration, false, 'seizurePeriod')
-  }
-
-  async refundSeizable (seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    const seizableScript = this.createSeizableScript(borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration)
-
-    return this._refund(seizableTxHash, seizableScript, borrowerPubKey, lenderPubKey, secretHashA1, secretHashB1, loanExpiration, biddingExpiration, seizureExpiration, true, 'refundPeriod')
-  }
-
-  async multisigSign (refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, isBorrower, to) {
-    const bidderPubKeyHash = hash160(bidderPubKey)
-
-    const refundableScript = this.createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashD1, loanExpiration, biddingExpiration)
-    const seizableScript = this.createSeizableScript(borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration)
-
-    const from = isBorrower ? pubKeyToAddress(borrowerPubKey, this._network.name, 'pubKeyHash') : pubKeyToAddress(lenderPubKey, this._network.name, 'pubKeyHash')
-
-    const refundableSignature = await this._multisigSign(refundableTxHash, refundableScript, loanExpiration, to, from)
-    const seizableSignature = await this._multisigSign(seizableTxHash, seizableScript, loanExpiration, to, from)
-
-    return { refundableSignature, seizableSignature }
-  }
-
-  async multisigSend (refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, signatureOne, signatureTwo, to) {
-    const bidderPubKeyHash = hash160(bidderPubKey)
-
-    const refundableScript = this.createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashD1, loanExpiration, biddingExpiration)
-    const seizableScript = this.createSeizableScript(borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration)
-
-    const refundableResult = await this._multisigSend(refundableTxHash, refundableScript, loanExpiration, signatureOne.refundableSignature, signatureTwo.refundableSignature, to)
-    const seizableResult = await this._multisigSend(seizableTxHash, seizableScript, loanExpiration, signatureOne.seizableSignature, signatureTwo.seizableSignature, to)
-
-    return { refundableResult, seizableResult }
-  }
-
-  doesTransactionMatchRefundableParams (transaction, refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    const data = this.createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration)
-    const scriptPubKey = padHexStart(data)
-    const receivingAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
-    const sendScript = this.getMethod('createScript')(receivingAddress)
-    return Boolean(transaction._raw.vout.find(vout => vout.scriptPubKey.hex === sendScript && vout.valueSat === refundableValue))
-  }
-
-  doesTransactionMatchSeizableParams (transaction, refundableValue, seizableValue, borrowerPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    const data = this.createSeizableScript(borrowerPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration)
-    const scriptPubKey = padHexStart(data)
-    const receivingAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
-    const sendScript = this.getMethod('createScript')(receivingAddress)
-    return Boolean(transaction._raw.vout.find(vout => vout.scriptPubKey.hex === sendScript && vout.valueSat === seizableValue))
-  }
-
-  async verifyLockRefundableTransaction (initiationTxHash, refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    const initiationTransaction = await this.getMethod('getTransactionByHash')(initiationTxHash)
-    return this.doesTransactionMatchRefundableParams(transaction, refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration)
-  }
-
-  async verifyLockSeizableTransaction (initiationTxHash, refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    const initiationTransaction = await this.getMethod('getTransactionByHash')(initiationTxHash)
-    return this.doesTransactionMatchSeizableParams(transaction, refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration)
-  }
-
-  async findRefundableTransaction (borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration, predicate) {
-    const script = this.createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration)
-    const scriptPubKey = padHexStart(script)
-    const p2shAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
-    let refundableTransaction = null
-    while (!refundableTransaction) {
-      let p2shTransactions = await this.getMethod('getAddressDeltas')([p2shAddress])
-      const p2shMempoolTransactions = await this.getMethod('getAddressMempool')([p2shAddress])
-      p2shTransactions = p2shTransactions.concat(p2shMempoolTransactions)
-      const transactionIds = p2shTransactions.map(tx => tx.txid)
-      const transactions = await Promise.all(transactionIds.map(this.getMethod('getTransactionByHash')))
-      refundableTransaction = transactions.find(predicate)
-      await sleep(5000)
-    }
-    return refundableTransaction
-  }
-
-  async findSeizableTransaction (borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, loanExpiration, biddingExpiration, seizureExpiration, predicate) {
-    const script = this.createSeizableScript(borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secrethashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration)
-    const scriptPubKey = padHexStart(script)
-    const p2shAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
-    let seizableTransaction = null
-    while (!seizableTransaction) {
-      let p2shTransactions = await this.getMethod('getAddressDeltas')([p2shAddress])
-      const p2shMempoolTransactions = await this.getMethod('getAddressMempool')([p2shAddress])
-      p2shTransactions = p2shTransactions.concat(p2shMempoolTransactions)
-      const transactionIds = p2shTransactions.map(tx => tx.txid)
-      const transactions = await Promise.all(transactionIds.map(this.getMethod('getTransactionByHash')))
-      seizableTransaction = transactions.find(predicate)
-      await sleep(5000)
-    }
-    return seizableTransaction
-  }
-
-  async findLockRefundableTransaction (refundableValue, seizableValue, borrowerPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, loanExpiration, biddingExpiration, seizureExpiration) {
-    const lockRefundableTransaction = await this.findRefundableTransaction(borrowerPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, loanExpiration, biddingExpiration, seizureExpiration,
-      tx => this.doesTransactionMatchRefundableParams(tx, refundableValue, seizableValue, borrowerPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, loanExpiration, biddingExpiration, seizureExpiration)
-    )
-
-    return lockRefundableTransaction
-  }
-
-  async findLockSeizableTransaction (refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    const lockSeizableTransaction = await this.findSeizableTransaction(borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, loanExpiration, biddingExpiration, seizureExpiration,
-      tx => this.doesTransactionMatchSeizableParams(tx, refundableValue, seizableValue, borrowerPubKey, agentPubKey, lenderPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, loanExpiration, biddingExpiration, seizureExpiration)
-    )
-
-    return lockSeizableTransaction
-  }
-
-  async _refund (initiationTxHash, script, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, borrowerSecretParam, bidderSecretParam, loanExpiration, biddingExpiration, seizureExpiration, seizable, period) {
-    let secret, lockTime
-    let requiresSecret = false
-    if (period === 'loanPeriod') {
-      secret = bidderSecretParam
-      requiresSecret = true
-    } else if (period === 'seizurePeriod' && seizable === true) {
-      secret = borrowerSecretParam
-      requiresSecret = true
-    }
-
-    if (period === 'loanPeriod') {
-      lockTime = 0
+    let ifBranch
+    if (period === 'claimPeriod') {
+      ifBranch = [ OPS.OP_TRUE ]
     } else if (period === 'biddingPeriod') {
-      lockTime = loanExpiration + 100
+      ifBranch = [ OPS.OP_TRUE, OPS.OP_FALSE ]
     } else if (period === 'seizurePeriod') {
-      lockTime = biddingExpiration + 100
+      ifBranch = [ OPS.OP_FALSE, OPS.OP_FALSE ]
+    }
+
+    let secretParams = []
+    for (let secret of secrets) {
+      secretParams.unshift(secret === null ? OPS.OP_FALSE : Buffer.from(secret, 'hex'))
+    }
+
+    const pubKeyParam = pubKey === null ? [] : [pubKey]
+    const multisigParams = period === 'biddingPeriod' ? [OPS.OP_0] : []
+
+    return bitcoin.script.compile([
+      ...multisigParams,
+      ...sigs,
+      ...pubKeyParam,
+      ...secretParams,
+      ...ifBranch
+    ])
+  }
+
+  getCollateralPaymentVariants (collateralOutput) {
+    const p2wsh = bitcoin.payments.p2wsh({
+      redeem: { output: collateralOutput, network: this._bitcoinJsNetwork },
+      network: this._bitcoinJsNetwork
+    })
+    const p2sh_p2wsh = bitcoin.payments.p2sh({
+      redeem: p2wsh, network: this._bitcoinJsNetwork
+    })
+    const p2sh = bitcoin.payments.p2sh({
+      redeem: { output: collateralOutput, network: this._bitcoinJsNetwork },
+      network: this._bitcoinJsNetwork
+    })
+
+    return { p2wsh, p2sh_p2wsh, p2sh }
+  }
+
+  async lock (values, pubKeys, secretHashes, expirations) {
+    const { refundableValue, seizableValue } = values
+
+    const refundableOutput = this.getCollateralOutput(pubKeys, secretHashes, expirations, true)
+    const seizableOutput = this.getCollateralOutput(pubKeys, secretHashes, expirations, false)
+
+    const refundableAddress = this.getCollateralPaymentVariants(refundableOutput)[this._mode.script].address
+    const seizableAddress = this.getCollateralPaymentVariants(seizableOutput)[this._mode.script].address
+
+    return this.getMethod('sendBatchTransaction')([
+      { to: refundableAddress, value: refundableValue },
+      { to: seizableAddress, value: seizableValue }
+    ])
+  }
+
+  async refund(txHash, pubKeys, secrets, secretHashes, expirations) {
+    const { secretHashA1, secretHashB1, secretHashC1, secretHashD1 } = secretHashes
+
+    if (secrets.length !== 3) { throw new Error('You should only provide 3 secrets') }
+
+    let orderedSecrets = [null, null, null, null]
+    for (let secret of secrets) {
+      if (sha256(secret) === secretHashA1) { orderedSecrets[0] = secret }
+      if (sha256(secret) === secretHashB1) { orderedSecrets[1] = secret }
+      if (sha256(secret) === secretHashC1) { orderedSecrets[2] = secret }
+      if (sha256(secret) === secretHashD1) { orderedSecrets[3] = secret }
+    }
+
+    return this._refundAll(txHash, pubKeys, orderedSecrets, secretHashes, expirations, 'claimPeriod')
+  }
+
+  async multisigSign (txHash, pubKeys, secretHashes, expirations, party, to) {
+    return this._multisigSign(txHash, pubKeys, secretHashes, expirations, party, to)
+  }
+
+  async multisigSend (txHash, sigs, pubKeys, secretHashes, expirations, to) {
+    return this._multisigSend(txHash, sigs, pubKeys, secretHashes, expirations, to)
+  }
+
+  async seize (txHash, pubKeys, secretHashes, expirations) {
+    return this._refundOne(txHash, pubKeys, secretHashes, expirations, 'seizurePeriod', true)
+  }
+
+  async reclaimOne (txHash, pubKeys, secretHashes, expirations) {
+    return this._refundOne(txHash, pubKeys, secretHashes, expirations, 'seizurePeriod', false)
+  }
+
+  async _refundOne (initiationTxHash, pubKeys, secretHashes, expirations, period, seizable) {
+    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const network = this._bitcoinJsNetwork
+    const pubKey = seizable ? lenderPubKey : borrowerPubKey
+    const address = this.pubKeyToAddress(Buffer.from(pubKey, 'hex'))
+    const wif = await this.getMethod('dumpPrivKey')(address)
+    const wallet = bitcoin.ECPair.fromWIF(wif, network)
+
+    const initiationTxRaw = await this.getMethod('getRawTransactionByHash')(initiationTxHash)
+    const initiationTx = await this.getMethod('decodeRawTransaction')(initiationTxRaw)
+
+    let col = {} // Collateral Object
+
+    col.output = this.getCollateralOutput(pubKeys, secretHashes, expirations, seizable)
+    col.colPaymentVariants = this.getCollateralPaymentVariants(col.output)
+    this.setPaymentVariants(initiationTx, col)
+    col.colVout.txid = initiationTxHash
+
+    const tx = this.buildColTx(period, col, expirations, address)
+
+    this.setHashForSigOrWit(tx, col, 0)
+    const colSig = bitcoin.script.signature.encode(wallet.sign(col.sigHash), bitcoin.Transaction.SIGHASH_ALL)
+    col.colInput = this.getCollateralInput(colSig, period, [], pubKey)
+
+    this.setHashForSigOrWit(tx, col, 0)
+    this.finalizeTx(tx, col, 0)
+
+    return this.getMethod('sendRawTransaction')(tx.toHex())
+  }
+
+  async _refundAll (initiationTxHash, pubKeys, secrets, secretHashes, expirations, period) {
+    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const network = this._bitcoinJsNetwork
+    const pubKey = (period === 'seizurePeriod') ? lenderPubKey : borrowerPubKey
+    const address = this.pubKeyToAddress(Buffer.from(pubKey, 'hex'))
+    const wif = await this.getMethod('dumpPrivKey')(address)
+    const wallet = bitcoin.ECPair.fromWIF(wif, network)
+
+    const initiationTxRaw = await this.getMethod('getRawTransactionByHash')(initiationTxHash)
+    const initiationTx = await this.getMethod('decodeRawTransaction')(initiationTxRaw)
+
+    let ref = {} // Refundable Object
+    let sei = {} // Seizable Object
+
+    ref.output = this.getCollateralOutput(pubKeys, secretHashes, expirations, true)
+    sei.output = this.getCollateralOutput(pubKeys, secretHashes, expirations, false)
+
+    ref.colPaymentVariants = this.getCollateralPaymentVariants(ref.output)
+    sei.colPaymentVariants = this.getCollateralPaymentVariants(sei.output)
+
+    this.setPaymentVariants(initiationTx, ref)
+    this.setPaymentVariants(initiationTx, sei)
+
+    ref.colVout.txid = initiationTxHash
+    sei.colVout.txid = initiationTxHash
+
+    const tx = this.buildFullColTx(period, ref, sei, expirations, address)
+
+    this.setHashForSigOrWit(tx, ref, 0)
+    this.setHashForSigOrWit(tx, sei, 1)
+
+    const refundableSig = bitcoin.script.signature.encode(wallet.sign(ref.sigHash), bitcoin.Transaction.SIGHASH_ALL)
+    const seizableSig = bitcoin.script.signature.encode(wallet.sign(sei.sigHash), bitcoin.Transaction.SIGHASH_ALL)
+
+    ref.colInput = this.getCollateralInput(refundableSig, period, secrets, pubKey)
+    sei.colInput = this.getCollateralInput(seizableSig, period, secrets, pubKey)
+
+    this.setHashForSigOrWit(tx, ref, 0)
+    this.setHashForSigOrWit(tx, sei, 1)
+
+    this.finalizeTx(tx, ref, 0)
+    this.finalizeTx(tx, sei, 1)
+
+    return this.getMethod('sendRawTransaction')(tx.toHex())
+  }
+
+  async _multisigSign (initiationTxHash, pubKeys, secretHashes, expirations, party, to) {
+    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { swapExpiration, biddingExpiration, seizureExpiration } = expirations
+    const period = 'biddingPeriod'
+    const network = this._bitcoinJsNetwork
+
+    const pubKey = party === 'lender' ? lenderPubKey : party === 'borrower' ? borrowerPubKey : agentPubKey
+    const address = this.pubKeyToAddress(Buffer.from(pubKey, 'hex'))
+
+    const wif = await this.getMethod('dumpPrivKey')(address)
+    const wallet = bitcoin.ECPair.fromWIF(wif, network)
+
+    const initiationTxRaw = await this.getMethod('getRawTransactionByHash')(initiationTxHash)
+    const initiationTx = await this.getMethod('decodeRawTransaction')(initiationTxRaw)
+
+    let ref = {} // Refundable Object
+    let sei = {} // Seizable Object
+
+    ref.output = this.getCollateralOutput(pubKeys, secretHashes, expirations, true)
+    sei.output = this.getCollateralOutput(pubKeys, secretHashes, expirations, false)
+
+    ref.colPaymentVariants = this.getCollateralPaymentVariants(ref.output)
+    sei.colPaymentVariants = this.getCollateralPaymentVariants(sei.output)
+
+    this.setPaymentVariants(initiationTx, ref)
+    this.setPaymentVariants(initiationTx, sei)
+
+    ref.colVout.txid = initiationTxHash
+    sei.colVout.txid = initiationTxHash
+
+    const tx = this.buildFullColTx(period, ref, sei, expirations, to)
+
+    this.setHashForSigOrWit(tx, ref, 0)
+    this.setHashForSigOrWit(tx, sei, 1)
+
+    const refundableSig = (bitcoin.script.signature.encode(wallet.sign(ref.sigHash), bitcoin.Transaction.SIGHASH_ALL)).toString('hex')
+    const seizableSig = (bitcoin.script.signature.encode(wallet.sign(sei.sigHash), bitcoin.Transaction.SIGHASH_ALL)).toString('hex')
+
+    return { refundableSig, seizableSig }
+  }
+
+  async _multisigSend (initiationTxHash, sigs, pubKeys, secretHashes, expirations, to) {
+    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const period = 'biddingPeriod'
+    const network = this._bitcoinJsNetwork
+
+    const initiationTxRaw = await this.getMethod('getRawTransactionByHash')(initiationTxHash)
+    const initiationTx = await this.getMethod('decodeRawTransaction')(initiationTxRaw)
+
+    let ref = {} // Refundable Object
+    let sei = {} // Seizable Object
+
+    ref.output = this.getCollateralOutput(pubKeys, secretHashes, expirations, true)
+    sei.output = this.getCollateralOutput(pubKeys, secretHashes, expirations, false)
+
+    ref.colPaymentVariants = this.getCollateralPaymentVariants(ref.output)
+    sei.colPaymentVariants = this.getCollateralPaymentVariants(sei.output)
+
+    this.setPaymentVariants(initiationTx, ref)
+    this.setPaymentVariants(initiationTx, sei)
+
+    ref.colVout.txid = initiationTxHash
+    sei.colVout.txid = initiationTxHash
+
+    const tx = this.buildFullColTx(period, ref, sei, expirations, to)
+
+    this.setHashForSigOrWit(tx, ref, 0)
+    this.setHashForSigOrWit(tx, sei, 1)
+
+    ref.colInput = this.getCollateralInput(sigs.refundable, period, [], null)
+    sei.colInput = this.getCollateralInput(sigs.seizable, period, [], null)
+
+    this.finalizeTx(tx, ref, 0)
+    this.finalizeTx(tx, sei, 1)
+
+    return this.getMethod('sendRawTransaction')(tx.toHex())
+  }
+
+  setPaymentVariants (initiationTx, col) {
+    for (const voutIndex in initiationTx._raw.data.vout) {
+      const vout = initiationTx._raw.data.vout[voutIndex]
+      const paymentVariantEntry = Object.entries(col.colPaymentVariants).find(([, payment]) => payment.output.toString('hex') === vout.scriptPubKey.hex)
+      if (paymentVariantEntry) {
+        col.paymentVariantName = paymentVariantEntry[0]
+        col.paymentVariant = paymentVariantEntry[1]
+        col.colVout = vout
+      }
+    }
+  }
+
+  buildColTx (period, col, expirations, to) {
+    const { swapExpiration, biddingExpiration } = expirations
+    const network = this._bitcoinJsNetwork
+
+    col.colVout.vSat = col.colVout.value * 1e8
+
+    const txb = new bitcoin.TransactionBuilder(network)
+
+    if (period === 'biddingPeriod') {
+      txb.setLockTime(swapExpiration)
+    } else if (period === 'seizurePeriod') {
+      txb.setLockTime(biddingExpiration)
+    }
+
+    col.prevOutScript = col.paymentVariant.output
+
+    // TODO: Implement proper fee calculation that counts bytes in inputs and outputs
+    // TODO: use node's feePerByte
+    const txfee = calculateFee(6, 6, 14)
+
+    txb.addInput(col.colVout.txid, col.colVout.n, 0, col.prevOutScript)
+    txb.addOutput(addressToString(to), col.colVout.vSat - txfee)
+
+    return txb.buildIncomplete()
+  }
+
+  buildFullColTx (period, ref, sei, expirations, to) {
+    const { swapExpiration, biddingExpiration } = expirations
+    const network = this._bitcoinJsNetwork
+
+    ref.colVout.vSat = ref.colVout.value * 1e8
+    sei.colVout.vSat = sei.colVout.value * 1e8
+
+    const txb = new bitcoin.TransactionBuilder(network)
+
+    if (period === 'biddingPeriod') {
+      txb.setLockTime(swapExpiration)
+    } else if (period === 'seizurePeriod') {
+      txb.setLockTime(biddingExpiration)
+    }
+
+    ref.prevOutScript = ref.paymentVariant.output
+    sei.prevOutScript = sei.paymentVariant.output
+
+    // TODO: Implement proper fee calculation that counts bytes in inputs and outputs
+    // TODO: use node's feePerByte
+    const txfee = calculateFee(6, 6, 14)
+
+    txb.addInput(ref.colVout.txid, ref.colVout.n, 0, ref.prevOutScript)
+    txb.addInput(sei.colVout.txid, sei.colVout.n, 0, sei.prevOutScript)
+    txb.addOutput(addressToString(to), ref.colVout.vSat + sei.colVout.vSat - txfee)
+
+    return txb.buildIncomplete()
+  }
+
+  setHashForSigOrWit (tx, col, i) {
+    const network = this._bitcoinJsNetwork
+    const needsWitness = col.paymentVariantName === 'p2wsh' || col.paymentVariantName === 'p2sh_p2wsh'
+
+    if (needsWitness) {
+      col.sigHash = tx.hashForWitnessV0(i, col.colPaymentVariants.p2wsh.redeem.output, col.colVout.vSat, bitcoin.Transaction.SIGHASH_ALL) // AMOUNT NEEDS TO BE PREVOUT AMOUNT
     } else {
-      lockTime = seizureExpiration + 100
+      col.sigHash = tx.hashForSignature(i, col.paymentVariant.redeem.output, bitcoin.Transaction.SIGHASH_ALL)
+    }
+  }
+
+  finalizeTx (tx, col, i) {
+    const network = this._bitcoinJsNetwork
+    const needsWitness = col.paymentVariantName === 'p2wsh' || col.paymentVariantName === 'p2sh_p2wsh'
+
+    col.paymentParams = { redeem: { output: col.output, input: col.colInput, network }, network }
+
+    col.paymentWithInput = needsWitness
+      ? bitcoin.payments.p2wsh(col.paymentParams)
+      : bitcoin.payments.p2sh(col.paymentParams)
+
+    if (needsWitness) {
+      tx.setWitness(i, col.paymentWithInput.witness)
     }
 
-    const lockTimeHex = padHexStart(scriptNumEncode(lockTime).toString('hex'), 8)
-
-    const pubKey = (period === 'seizurePeriod' && requiresSecret) ? lenderPubKey : bidderPubKey
-    const to = pubKeyToAddress(pubKey, this._network.name, 'pubKeyHash')
-
-    const scriptPubKey = padHexStart(script)
-    const p2shAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
-    const sendScript = this.getMethod('createScript')(p2shAddress)
-
-    const initiationTxRaw = await this.getMethod('getRawTransactionByHash')(initiationTxHash)
-    const initiationTx = await this.getMethod('splitTransaction')(initiationTxRaw, true)
-    const voutIndex = initiationTx.outputs.findIndex((output) => output.script.toString('hex') === sendScript)
-
-    const txHashLE = Buffer.from(initiationTxHash, 'hex').reverse().toString('hex') // TX HASH IN LITTLE ENDIAN
-    const newTxInput = this.generateSigTxInput(txHashLE, voutIndex, script)
-    const newTx = this.generateRawTx(initiationTx, voutIndex, to, newTxInput, lockTimeHex)
-    const splitNewTx = await this.getMethod('splitTransaction')(newTx, true)
-    const outputScriptObj = await this.getMethod('serializeTransactionOutputs')(splitNewTx)
-    const outputScript = outputScriptObj.toString('hex')
-
-    const walletAddress = await this.getMethod('getWalletAddress')(to)
-
-    const signature = await this.getMethod('signP2SHTransaction')(
-      [[initiationTx, voutIndex, script, 0]],
-      [walletAddress.derivationPath],
-      outputScript,
-      lockTime
-    )
-
-    const spend = this._spend(signature[0], pubKey, secret, requiresSecret, period)
-    const spendInput = this._spendInput(spend, script)
-    const rawClaimTxInput = this.generateRawTxInput(txHashLE, spendInput, voutIndex)
-    const rawClaimTx = this.generateRawTx(initiationTx, voutIndex, to, rawClaimTxInput, lockTimeHex)
-
-    return this.getMethod('sendRawTransaction')(rawClaimTx)
-  }
-
-  async _multisigSign (initiationTxHash, script, loanExpiration, to, from) {
-    const lockTime = loanExpiration + 100
-    const lockTimeHex = padHexStart(scriptNumEncode(lockTime).toString('hex'), 8)
-
-    const scriptPubKey = padHexStart(script)
-    const p2shAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
-    const sendScript = this.getMethod('createScript')(p2shAddress)
-
-    const initiationTxRaw = await this.getMethod('getRawTransactionByHash')(initiationTxHash)
-    const initiationTx = await this.getMethod('splitTransaction')(initiationTxRaw, true)
-    const voutIndex = initiationTx.outputs.findIndex((output) => output.script.toString('hex') === sendScript)
-
-    const txHashLE = Buffer.from(initiationTxHash, 'hex').reverse().toString('hex') // TX HASH IN LITTLE ENDIAN
-    const newTxInput = this.generateSigTxInput(txHashLE, voutIndex, script)
-    const newTx = this.generateRawTx(initiationTx, voutIndex, to, newTxInput, lockTimeHex)
-    const splitNewTx = await this.getMethod('splitTransaction')(newTx, true)
-    const outputScriptObj = await this.getMethod('serializeTransactionOutputs')(splitNewTx)
-    const outputScript = outputScriptObj.toString('hex')
-
-    const walletAddress = await this.getMethod('getWalletAddress')(from)
-
-    const signature = await this.getMethod('signP2SHTransaction')(
-      [[initiationTx, 0, script, 0]],
-      [walletAddress.derivationPath],
-      outputScript,
-      lockTime
-    )
-
-    return signature[0]
-  }
-
-  async _multisigSend (initiationTxHash, script, loanExpiration, signatureOne, signatureTwo, to) {
-    const lockTime = loanExpiration + 100
-    const lockTimeHex = padHexStart(scriptNumEncode(lockTime).toString('hex'), 8)
-
-    const scriptPubKey = padHexStart(script)
-    const p2shAddress = pubKeyToAddress(scriptPubKey, this._network.name, 'scriptHash')
-    const sendScript = this.getMethod('createScript')(p2shAddress)
-
-    const initiationTxRaw = await this.getMethod('getRawTransactionByHash')(initiationTxHash)
-    const initiationTx = await this.getMethod('splitTransaction')(initiationTxRaw, true)
-    const voutIndex = initiationTx.outputs.findIndex((output) => output.script.toString('hex') === sendScript)
-
-    const txHashLE = Buffer.from(initiationTxHash, 'hex').reverse().toString('hex') // TX HASH IN LITTLE ENDIAN
-
-    const spend = this._spendMultisig(signatureOne, signatureTwo)
-    const spendInput = this._spendInput(spend, script)
-
-    const rawClaimTxInput = this.generateRawTxInput(txHashLE, spendInput, voutIndex)
-    const rawClaimTx = this.generateRawTx(initiationTx, voutIndex, to, rawClaimTxInput, lockTimeHex)
-
-    return this.getMethod('sendRawTransaction')(rawClaimTx)
-  }
-
-  _spendMultisig (signatureOne, signatureTwo) {
-    const ifBranch = ['51', '00']
-
-    const signatureOneSignatureEncoded = signatureOne + '01'
-    const signatureOneSignaturePushDataOpcode = padHexStart((signatureOneSignatureEncoded.length / 2).toString(16))
-    const signatureTwoSignatureEncoded = signatureTwo + '01'
-    const signatureTwoSignaturePushDataOpcode = padHexStart((signatureTwoSignatureEncoded.length / 2).toString(16))
-
-    const bytecode = [
-      '00',
-      signatureOneSignaturePushDataOpcode,
-      signatureOneSignatureEncoded,
-      signatureTwoSignaturePushDataOpcode,
-      signatureTwoSignatureEncoded,
-      ...ifBranch
-    ]
-
-    return bytecode.join('')
-  }
-
-  _spend (signature, pubKey, secret, requiresSecret, period) {
-    var ifBranch
-    if (period === 'loanPeriod') {
-      ifBranch = ['51']
-    } else if (period === 'biddingPeriod') {
-      ifBranch = ['51', '00']
-    } else if (period === 'seizurePeriod' && requiresSecret) {
-      ifBranch = ['51', '00', '00']
-    } else if (period === 'seizurePeriod' && !requiresSecret) {
-      ifBranch = ['00', '00']
-    } else if (period === 'refundPeriod') {
-      ifBranch = ['00', '00', '00']
+    if (col.paymentVariantName === 'p2sh_p2wsh') {
+      // Adds the necessary push OP (PUSH34 (00 + witness script hash))
+      col.inputScript = bitcoin.script.compile([col.colPaymentVariants.p2sh_p2wsh.redeem.output])
+      tx.setInputScript(i, col.inputScript)
+    } else if (col.paymentVariantName === 'p2sh') {
+      tx.setInputScript(i, col.paymentWithInput.input)
     }
-
-    const encodedSecret = requiresSecret
-      ? [
-        padHexStart((secret.length / 2).toString(16)), // OP_PUSHDATA({secretLength})
-        secret
-      ]
-      : [] // OP_0
-
-    const signatureEncoded = signature + '01'
-    const signaturePushDataOpcode = padHexStart((signatureEncoded.length / 2).toString(16))
-    const pubKeyPushDataOpcode = padHexStart((pubKey.length / 2).toString(16))
-
-    const bytecode = [
-      signaturePushDataOpcode,
-      signatureEncoded,
-      pubKeyPushDataOpcode,
-      pubKey,
-      ...encodedSecret,
-      ...ifBranch
-    ]
-
-    return bytecode.join('')
-  }
-
-  _spendInput (spendBytecode, voutScript) {
-    const voutScriptLength = Buffer.from(padHexStart((voutScript.length / 2).toString(16)), 'hex').reverse().toString('hex')
-
-    const bytecode = [
-      spendBytecode,
-      (voutScript.length / 2) < 256 ? '4c' : '4d',
-      voutScriptLength,
-      voutScript
-    ]
-
-    return bytecode.join('')
-  }
-
-  generateSigTxInput (txHashLE, voutIndex, script) {
-    const inputTxOutput = Buffer.from(padHexStart(voutIndex.toString(16), 8), 'hex').reverse().toString('hex')
-    const scriptLength = Buffer.from(padHexStart((script.length / 2).toString(16)), 'hex').reverse().toString('hex')
-
-    return [
-      '01', // NUM INPUTS
-      txHashLE,
-      inputTxOutput, // INPUT TRANSACTION OUTPUT
-      (script.length / 2) < 253 ? '' : 'fd',
-      scriptLength,
-      (script.length / 2) >= 253 && (script.length / 2) < 256 ? '00' : '',
-      script,
-      '00000000' // SEQUENCE
-    ].join('')
-  }
-
-  generateRawTxInput (txHashLE, script, voutIndex) {
-    const inputTxOutput = Buffer.from(padHexStart(voutIndex.toString(16), 8), 'hex').reverse().toString('hex')
-    const scriptLength = Buffer.from(padHexStart((script.length / 2).toString(16)), 'hex').reverse().toString('hex')
-
-    return [
-      '01', // NUM INPUTS
-      txHashLE,
-      inputTxOutput,
-      (script.length / 2) < 253 ? '' : 'fd',
-      scriptLength,
-      (script.length / 2) >= 253 && (script.length / 2) < 256 ? '00' : '',
-      script,
-      '00000000' // SEQUENCE
-    ].join('')
-  }
-
-  generateRawTx (initiationTx, voutIndex, address, input, locktime) {
-    const output = initiationTx.outputs[voutIndex]
-    const value = parseInt(reverseBuffer(output.amount).toString('hex'), 16)
-    const fee = calculateFee(2, 2, 7)
-    const amount = value - fee
-    const amountLE = Buffer.from(padHexStart(amount.toString(16), 16), 'hex').reverse().toString('hex') // amount in little endian
-    const pubKeyHash = addressToPubKeyHash(address)
-
-    return [
-      '01000000', // VERSION
-      input,
-      '01', // NUM OUTPUTS
-      amountLE,
-      '19', // data size to be pushed
-      '76', // OP_DUP
-      'a9', // OP_HASH160
-      '14', // data size to be pushed
-      pubKeyHash, // <PUB_KEY_HASH>
-      '88', // OP_EQUALVERIFY
-      'ac', // OP_CHECKSIG
-      locktime // LOCKTIME
-    ].join('')
   }
 }
 

--- a/packages/loan-client/lib/CollateralSwap.js
+++ b/packages/loan-client/lib/CollateralSwap.js
@@ -3,39 +3,35 @@ export default class CollateralSwap {
     this.client = client
   }
 
-  async createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashD1, loanExpiration, biddingExpiration) {
-    return this.client.getMethod('createRefundableScript')(borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashD1, loanExpiration, biddingExpiration)
+  getCollateralOutput (pubKeys, secretHashes, expirations, seizable) {
+    return this.client.getMethod('getCollateralOutput')(pubKeys, secretHashes, expirations, seizable)
   }
 
-  async createSeizableScript (borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration) {
-    return this.client.getMethod('createSeizableScript')(borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration)
+  async lock (values, pubKeys, secretHashes, expirations) {
+    return this.client.getMethod('lock')(values, pubKeys, secretHashes, expirations)
   }
 
-  async lock (refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration) {
-    return this.client.getMethod('lock')(refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration)
+  async refund (txHashes, pubKeys, secret, secretHashes, expirations) {
+    return this.client.getMethod('refund')(txHashes, pubKeys, secret, secretHashes, expirations)
   }
 
-  async refund (refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashA1, secretD1, loanExpiration, biddingExpiration, seizureExpiration) {
-    return this.client.getMethod('refund')(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashA1, secretD1, loanExpiration, biddingExpiration, seizureExpiration)
+  async multisigSign (txHash, pubKeys, secretHashes, expirations, party, to) {
+    return this.client.getMethod('multisigSign')(txHash, pubKeys, secretHashes, expirations, party, to)
   }
 
-  async seize (seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    return this.client.getMethod('seize')(seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration)
+  async multisigSend (txHash, sigs, pubKeys, secrets, secretHashes, expirations, to) {
+    return this.client.getMethod('multisigSend')(txHash, sigs, pubKeys, secrets, secretHashes, expirations, to)
   }
 
-  async refundRefundable (refundableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    return this.client.getMethod('refundRefundable')(refundableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration)
+  async seize (txHash, pubKeys, secret, secretHashes, expirations) {
+    return this.client.getMethod('seize')(txHash, pubKeys, secret, secretHashes, expirations)
   }
 
-  async refundSeizable (seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration) {
-    return this.client.getMethod('refundSeizable')(seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration)
+  async reclaimOne (txHash, pubKeys, secretHashes, expirations, seizable) {
+    return this.client.getMethod('reclaimOne')(txHash, pubKeys, secretHashes, expirations, seizable)
   }
 
-  async multisigSign (refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, isBorrower, to) {
-    return this.client.getMethod('multisigSign')(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, isBorrower, to)
-  }
-
-  async multisigSend (refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, signatureOne, signatureTwo, to) {
-    return this.client.getMethod('multisigSend')(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, bidderPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, signatureOne, signatureTwo, to)
+  async reclaimAll (txHash, pubKeys, secretHashes, expirations) {
+    return this.client.getMethod('reclaimAll')(txHash, pubKeys, secretHashes, expirations)
   }
 }

--- a/packages/loan-client/lib/CollateralSwap.js
+++ b/packages/loan-client/lib/CollateralSwap.js
@@ -3,35 +3,31 @@ export default class CollateralSwap {
     this.client = client
   }
 
-  getCollateralOutput (pubKeys, secretHashes, expirations, seizable) {
-    return this.client.getMethod('getCollateralOutput')(pubKeys, secretHashes, expirations, seizable)
+  async init (values, pubKeys, secretHashes, expirations) {
+    return this.client.getMethod('init')(values, pubKeys, secretHashes, expirations)
   }
 
-  async lock (values, pubKeys, secretHashes, expirations) {
-    return this.client.getMethod('lock')(values, pubKeys, secretHashes, expirations)
+  async getInitAddresses (pubKeys, secretHashes, expirations) {
+    return this.client.getMethod('getInitAddresses')(pubKeys, secretHashes, expirations)
   }
 
-  async refund (txHashes, pubKeys, secret, secretHashes, expirations) {
-    return this.client.getMethod('refund')(txHashes, pubKeys, secret, secretHashes, expirations)
+  async claim (txHashes, pubKeys, secret, secretHashes, expirations) {
+    return this.client.getMethod('claim')(txHashes, pubKeys, secret, secretHashes, expirations)
   }
 
-  async multisigSign (txHash, pubKeys, secretHashes, expirations, party, to) {
-    return this.client.getMethod('multisigSign')(txHash, pubKeys, secretHashes, expirations, party, to)
+  async multisigWrite (txHash, pubKeys, secretHashes, expirations, party, to) {
+    return this.client.getMethod('multisigWrite')(txHash, pubKeys, secretHashes, expirations, party, to)
   }
 
-  async multisigSend (txHash, sigs, pubKeys, secrets, secretHashes, expirations, to) {
-    return this.client.getMethod('multisigSend')(txHash, sigs, pubKeys, secrets, secretHashes, expirations, to)
+  async multisigMove (txHash, sigs, pubKeys, secrets, secretHashes, expirations, to) {
+    return this.client.getMethod('multisigMove')(txHash, sigs, pubKeys, secrets, secretHashes, expirations, to)
   }
 
-  async seize (txHash, pubKeys, secret, secretHashes, expirations) {
-    return this.client.getMethod('seize')(txHash, pubKeys, secret, secretHashes, expirations)
+  async snatch (txHash, pubKeys, secretHashes, expirations) {
+    return this.client.getMethod('snatch')(txHash, pubKeys, secretHashes, expirations)
   }
 
-  async reclaimOne (txHash, pubKeys, secretHashes, expirations, seizable) {
-    return this.client.getMethod('reclaimOne')(txHash, pubKeys, secretHashes, expirations, seizable)
-  }
-
-  async reclaimAll (txHash, pubKeys, secretHashes, expirations) {
-    return this.client.getMethod('reclaimAll')(txHash, pubKeys, secretHashes, expirations)
+  async regain (txHash, pubKeys, secretHashes, expirations) {
+    return this.client.getMethod('regain')(txHash, pubKeys, secretHashes, expirations)
   }
 }

--- a/packages/loan-client/lib/LoanClient.js
+++ b/packages/loan-client/lib/LoanClient.js
@@ -113,8 +113,12 @@ export default class LoanClient {
    * @return {function} Returns method from provider instance associated with the requested method
    */
   getMethod (method, requestor) {
-    const provider = this.getProviderForMethod(method, requestor)
-    return provider[method].bind(provider)
+    try {
+      const provider = this.getProviderForMethod(method, requestor)
+      return provider[method].bind(provider)
+    } catch(e) {
+      return this.client.getMethod(method)
+    }
   }
 
   get collateral () {

--- a/test/integration/collateral/collateral.js
+++ b/test/integration/collateral/collateral.js
@@ -78,10 +78,7 @@ function testCollateral (chain) {
   it('should allow multisig signing and sending', async () => {
     const { lockTxHash, colParams } = await lockCollateral(chain, 'approveExpiration')
 
-    const to = await chain.client.getMethod('getNewAddress')('p2sh-segwit')
-
-    const balBefore = await chain.client.getMethod('getBalance')(to)
-    console.log('balBefore')
+    const to = await chain.client.getMethod('getNewAddress')()
 
     const multisigBorrowerParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'borrower', to]
     const borrowerSigs = await chain.client.loan.collateral.multisigSign(...multisigBorrowerParams)

--- a/test/integration/collateral/collateralSwap.js
+++ b/test/integration/collateral/collateralSwap.js
@@ -1,0 +1,171 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { chains, getUnusedPubKey, getCollateralParams } from '../common'
+import config from '../config'
+import { hash160 } from '@liquality/crypto'
+import { pubKeyToAddress } from '@liquality/bitcoin-utils'
+
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
+
+chai.use(chaiAsPromised)
+chai.use(require('chai-bignumber')())
+
+function testCollateral (chain) {
+  it('should allow locking and claiming', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain)
+
+    const secrets = [colParams.secrets.secretB1, colParams.secrets.secretC1, colParams.secrets.secretD1]
+    const refundParams = [lockTxHash, colParams.pubKeys, secrets, colParams.secretHashes, colParams.expirations]
+
+    const refundTxHash = await chain.client.loan.collateralSwap.refund(...refundParams)
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const refundTxRaw = await chain.client.getMethod('getRawTransactionByHash')(refundTxHash)
+    const refundTx = await chain.client.getMethod('decodeRawTransaction')(refundTxRaw)
+
+    const refundVouts = refundTx._raw.data.vout
+    const refundVins = refundTx._raw.data.vin
+
+    expect(refundVins.length).to.equal(2)
+    expect(refundVouts.length).to.equal(1)
+
+    expect(getVinRedeemScript(refundVins[0]).includes(colParams.secrets.secretB1)).to.equal(true)
+    expect(getVinRedeemScript(refundVins[1]).includes(colParams.secrets.secretB1)).to.equal(true)
+  })
+
+  it('should allow multisig signing', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'swapExpiration')
+
+    const to = await chain.client.getMethod('getNewAddress')('p2sh-segwit')
+    const multisigParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'borrower', to]
+    const { refundableSig, seizableSig } = await chain.client.loan.collateralSwap.multisigSign(...multisigParams)
+
+    expect(refundableSig.startsWith('30')).to.equal(true)
+    expect(seizableSig.startsWith('30')).to.equal(true)
+
+    expect(71 <= Buffer.from(refundableSig, 'hex').length <= 72).to.equal(true)
+    expect(71 <= Buffer.from(seizableSig, 'hex').length <= 72).to.equal(true)
+  })
+
+  it('should allow multisig signing and sending', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'swapExpiration')
+
+    const to = await chain.client.getMethod('getNewAddress')('p2sh-segwit')
+
+    const balBefore = await chain.client.getMethod('getBalance')(to)
+    console.log('balBefore')
+
+    const multisigBorrowerParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'borrower', to]
+    const borrowerSigs = await chain.client.loan.collateralSwap.multisigSign(...multisigBorrowerParams)
+
+    const multisigParamsLender = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'lender', to]
+    const lenderSigs = await chain.client.loan.collateralSwap.multisigSign(...multisigParamsLender)
+
+    const sigs = {
+      refundable: [Buffer.from(borrowerSigs.refundableSig, 'hex'), Buffer.from(lenderSigs.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs.seizableSig, 'hex'), Buffer.from(lenderSigs.seizableSig, 'hex')]
+    }
+
+    const multisigSendTxHash = await chain.client.loan.collateralSwap.multisigSend(lockTxHash, sigs, colParams.pubKeys, colParams.secretHashes, colParams.expirations, to)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const multisigSendTxRaw = await chain.client.getMethod('getRawTransactionByHash')(multisigSendTxHash)
+    const multisigSendTx = await chain.client.getMethod('decodeRawTransaction')(multisigSendTxRaw)
+
+    const multisigSendVouts = multisigSendTx._raw.data.vout
+    const multisigSendVins = multisigSendTx._raw.data.vin
+
+    expect(multisigSendVins.length).to.equal(2)
+    expect(multisigSendVouts.length).to.equal(1)
+  })
+
+  it('should allow multisig signing and sending', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'swapExpiration')
+
+    const to = await chain.client.getMethod('getNewAddress')('p2sh-segwit')
+
+    const multisigBorrowerParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'borrower', to]
+    const borrowerSigs = await chain.client.loan.collateralSwap.multisigSign(...multisigBorrowerParams)
+
+    const multisigParamsLender = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'lender', to]
+    const lenderSigs = await chain.client.loan.collateralSwap.multisigSign(...multisigParamsLender)
+
+    const sigs = {
+      refundable: [Buffer.from(borrowerSigs.refundableSig, 'hex'), Buffer.from(lenderSigs.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs.seizableSig, 'hex'), Buffer.from(lenderSigs.seizableSig, 'hex')]
+    }
+
+    const multisigSendTxHash = await chain.client.loan.collateralSwap.multisigSend(lockTxHash, sigs, colParams.pubKeys, colParams.secretHashes, colParams.expirations, to)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const multisigSendTxRaw = await chain.client.getMethod('getRawTransactionByHash')(multisigSendTxHash)
+    const multisigSendTx = await chain.client.getMethod('decodeRawTransaction')(multisigSendTxRaw)
+
+    const multisigSendVouts = multisigSendTx._raw.data.vout
+    const multisigSendVins = multisigSendTx._raw.data.vin
+
+    expect(multisigSendVins.length).to.equal(2)
+    expect(multisigSendVouts.length).to.equal(1)
+  })
+
+  it('should allow seizure', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'biddingExpiration')
+
+    const seizeParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations]
+    const seizeTxHash = await chain.client.loan.collateralSwap.seize(...seizeParams)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const seizeTxRaw = await chain.client.getMethod('getRawTransactionByHash')(seizeTxHash)
+    const seizeTx = await chain.client.getMethod('decodeRawTransaction')(seizeTxRaw)
+
+    const seizeVouts = seizeTx._raw.data.vout
+    const seizeVins = seizeTx._raw.data.vin
+
+    expect(seizeVins.length).to.equal(1)
+    expect(seizeVouts.length).to.equal(1)
+  })
+
+  it('should allow reclaiming of refundable collateral', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'biddingExpiration')
+
+    const reclaimOneParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations]
+    const reclaimTx = await chain.client.loan.collateralSwap.reclaimOne(...reclaimOneParams)
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+  })
+}
+
+async function lockCollateral (chain, customExpiration) {
+  let colParams = await getCollateralParams(chain)
+  const lockParams = [colParams.values, colParams.pubKeys, colParams.secretHashes, colParams.expirations]
+
+  if (customExpiration) {
+    const curTimeExpiration = Math.floor((new Date()).getTime() / 1000) - 1000
+    colParams.expirations[customExpiration] = curTimeExpiration
+  }
+
+  const lockTxHash = await chain.client.loan.collateralSwap.lock(...lockParams)
+  await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+  return { lockTxHash, colParams }
+}
+
+function getVinRedeemScript (vin) {
+  if (vin.txinwitness == undefined) {
+    return vin.scriptSig.hex
+  } else {
+    return vin.txinwitness
+  }
+}
+
+describe('Collateral Flow', function () {
+  this.timeout(config.timeout)
+
+  describe('Bitcoin - Node', () => {
+    testCollateral(chains.bitcoinNodeCollateralSwap)
+  })
+})

--- a/test/integration/collateral/liquidation.js
+++ b/test/integration/collateral/liquidation.js
@@ -48,6 +48,271 @@ function testCollateral (chain) {
 
     const claimTxHash = await chain.client.loan.collateralSwap.claim(...claimParams)
   })
+
+  it('should lock collateral, liquidate by multisigsend to collateral swap and claim by liquidator', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'approveExpiration')
+
+    const swapSecretHashes = {
+      secretHashA1: colParams.secretHashes.secretHashA2,
+      secretHashB1: colParams.secretHashes.secretHashB2,
+      secretHashC1: colParams.secretHashes.secretHashC2,
+      secretHashD1: colParams.secretHashes.secretHashD1
+    }
+
+    const curTimeExpiration = Math.floor((new Date()).getTime() / 1000) - 1000
+    colParams.expirations.swapExpiration = curTimeExpiration
+
+    const swapParams = [colParams.pubKeys, swapSecretHashes, colParams.expirations]
+    const lockAddresses = await chain.client.loan.collateralSwap.getInitAddresses(...swapParams)
+
+    const outputs = [{ address: lockAddresses.refundableAddress }, { address: lockAddresses.seizableAddress }]
+
+    const multisigBorrowerParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'borrower', outputs]
+    const borrowerSigs = await chain.client.loan.collateral.multisigSign(...multisigBorrowerParams)
+
+    const multisigParamsLender = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'lender', outputs]
+    const lenderSigs = await chain.client.loan.collateral.multisigSign(...multisigParamsLender)
+
+    const sigs = {
+      refundable: [Buffer.from(borrowerSigs.refundableSig, 'hex'), Buffer.from(lenderSigs.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs.seizableSig, 'hex'), Buffer.from(lenderSigs.seizableSig, 'hex')]
+    }
+
+    const multisigSendTxHash = await chain.client.loan.collateral.multisigSend(lockTxHash, sigs, colParams.pubKeys, colParams.secretHashes, colParams.expirations, outputs)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const swapSecretHashes2 = {
+      secretHashA1: colParams.secretHashes.secretHashA3,
+      secretHashB1: colParams.secretHashes.secretHashB3,
+      secretHashC1: colParams.secretHashes.secretHashC3,
+      secretHashD1: colParams.secretHashes.secretHashD2
+    }
+
+    const swapParams2 = [colParams.pubKeys, swapSecretHashes2, colParams.expirations]
+    const lockAddresses2 = await chain.client.loan.collateralSwap.getInitAddresses(...swapParams2)
+
+    const outputs2 = [{ address: lockAddresses2.refundableAddress }, { address: lockAddresses2.seizableAddress }]
+
+    const multisigBorrowerParams2 = [multisigSendTxHash, colParams.pubKeys, swapSecretHashes, colParams.expirations, 'borrower', outputs2]
+    const borrowerSigs2 = await chain.client.loan.collateralSwap.multisigWrite(...multisigBorrowerParams2)
+
+    const multisigParamsLender2 = [multisigSendTxHash, colParams.pubKeys, swapSecretHashes, colParams.expirations, 'lender', outputs2]
+    const lenderSigs2 = await chain.client.loan.collateralSwap.multisigWrite(...multisigParamsLender2)
+
+    const sigs2 = {
+      refundable: [Buffer.from(borrowerSigs2.refundableSig, 'hex'), Buffer.from(lenderSigs2.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs2.seizableSig, 'hex'), Buffer.from(lenderSigs2.seizableSig, 'hex')]
+    }
+
+    const multisigMoveTxHash = await chain.client.loan.collateralSwap.multisigMove(multisigSendTxHash, sigs2, colParams.pubKeys, swapSecretHashes, colParams.expirations, outputs2)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const secrets2 = [colParams.secrets.secretB3, colParams.secrets.secretC3, colParams.secrets.secretD2]
+    const claimParams = [multisigMoveTxHash, colParams.pubKeys, secrets2, swapSecretHashes2, colParams.expirations]
+
+    const claimTxHash2 = await chain.client.loan.collateralSwap.claim(...claimParams)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+  })
+
+  it('should lock collateral, attempt liquidation with multisig send, attempt liquidation twice more with multisigmove and finally claim', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'approveExpiration')
+
+    const swapSecretHashes = {
+      secretHashA1: colParams.secretHashes.secretHashA2,
+      secretHashB1: colParams.secretHashes.secretHashB2,
+      secretHashC1: colParams.secretHashes.secretHashC2,
+      secretHashD1: colParams.secretHashes.secretHashD1
+    }
+
+    const curTimeExpiration = Math.floor((new Date()).getTime() / 1000) - 1000
+    colParams.expirations.swapExpiration = curTimeExpiration
+
+    const swapParams = [colParams.pubKeys, swapSecretHashes, colParams.expirations]
+    const lockAddresses = await chain.client.loan.collateralSwap.getInitAddresses(...swapParams)
+
+    const outputs = [{ address: lockAddresses.refundableAddress }, { address: lockAddresses.seizableAddress }]
+
+    const multisigBorrowerParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'borrower', outputs]
+    const borrowerSigs = await chain.client.loan.collateral.multisigSign(...multisigBorrowerParams)
+
+    const multisigParamsLender = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'lender', outputs]
+    const lenderSigs = await chain.client.loan.collateral.multisigSign(...multisigParamsLender)
+
+    const sigs = {
+      refundable: [Buffer.from(borrowerSigs.refundableSig, 'hex'), Buffer.from(lenderSigs.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs.seizableSig, 'hex'), Buffer.from(lenderSigs.seizableSig, 'hex')]
+    }
+
+    const multisigSendTxHash = await chain.client.loan.collateral.multisigSend(lockTxHash, sigs, colParams.pubKeys, colParams.secretHashes, colParams.expirations, outputs)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const swapSecretHashes2 = {
+      secretHashA1: colParams.secretHashes.secretHashA3,
+      secretHashB1: colParams.secretHashes.secretHashB3,
+      secretHashC1: colParams.secretHashes.secretHashC3,
+      secretHashD1: colParams.secretHashes.secretHashD2
+    }
+
+    const swapParams2 = [colParams.pubKeys, swapSecretHashes2, colParams.expirations]
+    const lockAddresses2 = await chain.client.loan.collateralSwap.getInitAddresses(...swapParams2)
+
+    const outputs2 = [{ address: lockAddresses2.refundableAddress }, { address: lockAddresses2.seizableAddress }]
+
+    const multisigBorrowerParams2 = [multisigSendTxHash, colParams.pubKeys, swapSecretHashes, colParams.expirations, 'borrower', outputs2]
+    const borrowerSigs2 = await chain.client.loan.collateralSwap.multisigWrite(...multisigBorrowerParams2)
+
+    const multisigParamsLender2 = [multisigSendTxHash, colParams.pubKeys, swapSecretHashes, colParams.expirations, 'lender', outputs2]
+    const lenderSigs2 = await chain.client.loan.collateralSwap.multisigWrite(...multisigParamsLender2)
+
+    const sigs2 = {
+      refundable: [Buffer.from(borrowerSigs2.refundableSig, 'hex'), Buffer.from(lenderSigs2.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs2.seizableSig, 'hex'), Buffer.from(lenderSigs2.seizableSig, 'hex')]
+    }
+
+    const multisigMoveTxHash = await chain.client.loan.collateralSwap.multisigMove(multisigSendTxHash, sigs2, colParams.pubKeys, swapSecretHashes, colParams.expirations, outputs2)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const swapSecretHashes3 = {
+      secretHashA1: colParams.secretHashes.secretHashA4,
+      secretHashB1: colParams.secretHashes.secretHashB4,
+      secretHashC1: colParams.secretHashes.secretHashC4,
+      secretHashD1: colParams.secretHashes.secretHashD3
+    }
+
+    const swapParams3 = [colParams.pubKeys, swapSecretHashes3, colParams.expirations]
+    const lockAddresses3 = await chain.client.loan.collateralSwap.getInitAddresses(...swapParams3)
+
+    const outputs3 = [{ address: lockAddresses3.refundableAddress }, { address: lockAddresses3.seizableAddress }]
+
+    const multisigBorrowerParams3 = [multisigMoveTxHash, colParams.pubKeys, swapSecretHashes2, colParams.expirations, 'borrower', outputs3]
+    const borrowerSigs3 = await chain.client.loan.collateralSwap.multisigWrite(...multisigBorrowerParams3)
+
+    const multisigParamsLender3 = [multisigMoveTxHash, colParams.pubKeys, swapSecretHashes2, colParams.expirations, 'lender', outputs3]
+    const lenderSigs3 = await chain.client.loan.collateralSwap.multisigWrite(...multisigParamsLender3)
+
+    const sigs3 = {
+      refundable: [Buffer.from(borrowerSigs3.refundableSig, 'hex'), Buffer.from(lenderSigs3.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs3.seizableSig, 'hex'), Buffer.from(lenderSigs3.seizableSig, 'hex')]
+    }
+
+    const multisigMoveTxHash2 = await chain.client.loan.collateralSwap.multisigMove(multisigMoveTxHash, sigs3, colParams.pubKeys, swapSecretHashes2, colParams.expirations, outputs3)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const secrets2 = [colParams.secrets.secretB4, colParams.secrets.secretC4, colParams.secrets.secretD3]
+    const claimParams = [multisigMoveTxHash2, colParams.pubKeys, secrets2, swapSecretHashes3, colParams.expirations]
+
+    const claimTxHash2 = await chain.client.loan.collateralSwap.claim(...claimParams)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+  })
+
+  it('should lock collateral, attempt liquidation with multisig send, attempt liquidation twice more with multisigmove and finally snatch/regain', async () => {
+    let colParams = await getCollateralParams(chain)
+    const lockParams = [colParams.values, colParams.pubKeys, colParams.secretHashes, colParams.expirations]
+
+    const curTimeExpiration = Math.floor((new Date()).getTime() / 1000) - 1000
+    colParams.expirations.approveExpiration = curTimeExpiration
+    colParams.expirations.biddingExpiration = curTimeExpiration
+    colParams.expirations.swapExpiration = curTimeExpiration
+
+    const lockTxHash = await chain.client.loan.collateral.lock(...lockParams)
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const swapSecretHashes = {
+      secretHashA1: colParams.secretHashes.secretHashA2,
+      secretHashB1: colParams.secretHashes.secretHashB2,
+      secretHashC1: colParams.secretHashes.secretHashC2,
+      secretHashD1: colParams.secretHashes.secretHashD1
+    }
+
+    const swapParams = [colParams.pubKeys, swapSecretHashes, colParams.expirations]
+    const lockAddresses = await chain.client.loan.collateralSwap.getInitAddresses(...swapParams)
+
+    const outputs = [{ address: lockAddresses.refundableAddress }, { address: lockAddresses.seizableAddress }]
+
+    const multisigBorrowerParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'borrower', outputs]
+    const borrowerSigs = await chain.client.loan.collateral.multisigSign(...multisigBorrowerParams)
+
+    const multisigParamsLender = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'lender', outputs]
+    const lenderSigs = await chain.client.loan.collateral.multisigSign(...multisigParamsLender)
+
+    const sigs = {
+      refundable: [Buffer.from(borrowerSigs.refundableSig, 'hex'), Buffer.from(lenderSigs.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs.seizableSig, 'hex'), Buffer.from(lenderSigs.seizableSig, 'hex')]
+    }
+
+    const multisigSendTxHash = await chain.client.loan.collateral.multisigSend(lockTxHash, sigs, colParams.pubKeys, colParams.secretHashes, colParams.expirations, outputs)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const swapSecretHashes2 = {
+      secretHashA1: colParams.secretHashes.secretHashA3,
+      secretHashB1: colParams.secretHashes.secretHashB3,
+      secretHashC1: colParams.secretHashes.secretHashC3,
+      secretHashD1: colParams.secretHashes.secretHashD2
+    }
+
+    const swapParams2 = [colParams.pubKeys, swapSecretHashes2, colParams.expirations]
+    const lockAddresses2 = await chain.client.loan.collateralSwap.getInitAddresses(...swapParams2)
+
+    const outputs2 = [{ address: lockAddresses2.refundableAddress }, { address: lockAddresses2.seizableAddress }]
+
+    const multisigBorrowerParams2 = [multisigSendTxHash, colParams.pubKeys, swapSecretHashes, colParams.expirations, 'borrower', outputs2]
+    const borrowerSigs2 = await chain.client.loan.collateralSwap.multisigWrite(...multisigBorrowerParams2)
+
+    const multisigParamsLender2 = [multisigSendTxHash, colParams.pubKeys, swapSecretHashes, colParams.expirations, 'lender', outputs2]
+    const lenderSigs2 = await chain.client.loan.collateralSwap.multisigWrite(...multisigParamsLender2)
+
+    const sigs2 = {
+      refundable: [Buffer.from(borrowerSigs2.refundableSig, 'hex'), Buffer.from(lenderSigs2.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs2.seizableSig, 'hex'), Buffer.from(lenderSigs2.seizableSig, 'hex')]
+    }
+
+    const multisigMoveTxHash = await chain.client.loan.collateralSwap.multisigMove(multisigSendTxHash, sigs2, colParams.pubKeys, swapSecretHashes, colParams.expirations, outputs2)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const swapSecretHashes3 = {
+      secretHashA1: colParams.secretHashes.secretHashA4,
+      secretHashB1: colParams.secretHashes.secretHashB4,
+      secretHashC1: colParams.secretHashes.secretHashC4,
+      secretHashD1: colParams.secretHashes.secretHashD3
+    }
+
+    const swapParams3 = [colParams.pubKeys, swapSecretHashes3, colParams.expirations]
+    const lockAddresses3 = await chain.client.loan.collateralSwap.getInitAddresses(...swapParams3)
+
+    const outputs3 = [{ address: lockAddresses3.refundableAddress }, { address: lockAddresses3.seizableAddress }]
+
+    const multisigBorrowerParams3 = [multisigMoveTxHash, colParams.pubKeys, swapSecretHashes2, colParams.expirations, 'borrower', outputs3]
+    const borrowerSigs3 = await chain.client.loan.collateralSwap.multisigWrite(...multisigBorrowerParams3)
+
+    const multisigParamsLender3 = [multisigMoveTxHash, colParams.pubKeys, swapSecretHashes2, colParams.expirations, 'lender', outputs3]
+    const lenderSigs3 = await chain.client.loan.collateralSwap.multisigWrite(...multisigParamsLender3)
+
+    const sigs3 = {
+      refundable: [Buffer.from(borrowerSigs3.refundableSig, 'hex'), Buffer.from(lenderSigs3.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs3.seizableSig, 'hex'), Buffer.from(lenderSigs3.seizableSig, 'hex')]
+    }
+
+    const multisigMoveTxHash2 = await chain.client.loan.collateralSwap.multisigMove(multisigMoveTxHash, sigs3, colParams.pubKeys, swapSecretHashes2, colParams.expirations, outputs3)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const recoverParams = [multisigMoveTxHash2, colParams.pubKeys, swapSecretHashes3, colParams.expirations]
+
+    const snatchTxHash = await chain.client.loan.collateralSwap.snatch(...recoverParams)
+
+    const regainTxHash = await chain.client.loan.collateralSwap.regain(...recoverParams)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+  })
 }
 
 async function lockCollateral (chain, customExpiration) {

--- a/test/integration/collateral/liquidation.js
+++ b/test/integration/collateral/liquidation.js
@@ -1,0 +1,82 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { chains, getUnusedPubKey, getCollateralParams } from '../common'
+import config from '../config'
+import { hash160 } from '@liquality/crypto'
+import { pubKeyToAddress } from '@liquality/bitcoin-utils'
+
+process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
+
+chai.use(chaiAsPromised)
+chai.use(require('chai-bignumber')())
+
+function testCollateral (chain) {
+  it('should lock collateral, liquidate by multisigsend to collateral swap and claim by liquidator', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'approveExpiration')
+
+    const swapSecretHashes = {
+      secretHashA1: colParams.secretHashes.secretHashA2,
+      secretHashB1: colParams.secretHashes.secretHashB2,
+      secretHashC1: colParams.secretHashes.secretHashC2,
+      secretHashD1: colParams.secretHashes.secretHashD1
+    }
+
+    const swapParams = [colParams.pubKeys, swapSecretHashes, colParams.expirations]
+    const lockAddresses = await chain.client.loan.collateralSwap.getInitAddresses(...swapParams)
+
+    const outputs = [{ address: lockAddresses.refundableAddress }, { address: lockAddresses.seizableAddress }]
+
+    const multisigBorrowerParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'borrower', outputs]
+    const borrowerSigs = await chain.client.loan.collateral.multisigSign(...multisigBorrowerParams)
+
+    const multisigParamsLender = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'lender', outputs]
+    const lenderSigs = await chain.client.loan.collateral.multisigSign(...multisigParamsLender)
+
+    const sigs = {
+      refundable: [Buffer.from(borrowerSigs.refundableSig, 'hex'), Buffer.from(lenderSigs.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs.seizableSig, 'hex'), Buffer.from(lenderSigs.seizableSig, 'hex')]
+    }
+
+    const multisigSendTxHash = await chain.client.loan.collateral.multisigSend(lockTxHash, sigs, colParams.pubKeys, colParams.secretHashes, colParams.expirations, outputs)
+
+    await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+    const secrets = [colParams.secrets.secretB2, colParams.secrets.secretC2, colParams.secrets.secretD1]
+    const claimParams = [multisigSendTxHash, colParams.pubKeys, secrets, swapSecretHashes, colParams.expirations]
+
+    const claimTxHash = await chain.client.loan.collateralSwap.claim(...claimParams)
+  })
+}
+
+async function lockCollateral (chain, customExpiration) {
+  let colParams = await getCollateralParams(chain)
+  const lockParams = [colParams.values, colParams.pubKeys, colParams.secretHashes, colParams.expirations]
+
+  if (customExpiration) {
+    const curTimeExpiration = Math.floor((new Date()).getTime() / 1000) - 1000
+    colParams.expirations[customExpiration] = curTimeExpiration
+  }
+
+  const lockTxHash = await chain.client.loan.collateral.lock(...lockParams)
+  await chains.bitcoinWithNode.client.chain.generateBlock(1)
+
+  return { lockTxHash, colParams }
+}
+
+function getVinRedeemScript (vin) {
+  if (vin.txinwitness == undefined) {
+    return vin.scriptSig.hex
+  } else {
+    return vin.txinwitness
+  }
+}
+
+describe('Collateral Liquidation Flow', function () {
+  this.timeout(config.timeout)
+
+  describe('Bitcoin - Node', () => {
+    testCollateral(chains.bitcoinWithNode)
+  })
+})

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -24,6 +24,7 @@ const bitcoinLoanWithNode = new LoanClient(bitcoinWithNode)
 bitcoinWithNode.loan = bitcoinLoanWithNode
 bitcoinWithNode.addProvider(new providers.bitcoin.BitcoinRpcProvider(config.bitcoin.rpc.host, config.bitcoin.rpc.username, config.bitcoin.rpc.password))
 bitcoinWithNode.loan.addProvider(new lproviders.bitcoin.BitcoinCollateralProvider({ network: bitcoinNetworks[config.bitcoin.network] }, { script: 'p2sh', address: 'p2wpkh'}))
+bitcoinWithNode.loan.addProvider(new lproviders.bitcoin.BitcoinCollateralSwapProvider({ network: bitcoinNetworks[config.bitcoin.network] }, { script: 'p2sh', address: 'p2wpkh'}))
 
 const bitcoinNodeCollateralSwap = new Client()
 const bitcoinLoanNodeCollateralSwap = new LoanClient(bitcoinNodeCollateralSwap)
@@ -78,22 +79,48 @@ const chains = {
 async function getCollateralSecretParams (chain) {
   const secretA1 = await chain.client.swap.generateSecret('secretA1')
   const secretA2 = await chain.client.swap.generateSecret('secretA2')
+  const secretA3 = await chain.client.swap.generateSecret('secretA3')
+  const secretA4 = await chain.client.swap.generateSecret('secretA4')
   const secretB1 = await chain.client.swap.generateSecret('secretB1')
   const secretB2 = await chain.client.swap.generateSecret('secretB2')
+  const secretB3 = await chain.client.swap.generateSecret('secretB3')
+  const secretB4 = await chain.client.swap.generateSecret('secretB4')
   const secretC1 = await chain.client.swap.generateSecret('secretC1')
   const secretC2 = await chain.client.swap.generateSecret('secretC2')
+  const secretC3 = await chain.client.swap.generateSecret('secretC3')
+  const secretC4 = await chain.client.swap.generateSecret('secretC4')
   const secretD1 = await chain.client.swap.generateSecret('secretD1')
+  const secretD2 = await chain.client.swap.generateSecret('secretD2')
+  const secretD3 = await chain.client.swap.generateSecret('secretD3')
 
   const secretHashA1 = sha256(secretA1)
   const secretHashA2 = sha256(secretA2)
+  const secretHashA3 = sha256(secretA3)
+  const secretHashA4 = sha256(secretA4)
   const secretHashB1 = sha256(secretB1)
   const secretHashB2 = sha256(secretB2)
+  const secretHashB3 = sha256(secretB3)
+  const secretHashB4 = sha256(secretB4)
   const secretHashC1 = sha256(secretC1)
   const secretHashC2 = sha256(secretC2)
+  const secretHashC3 = sha256(secretC3)
+  const secretHashC4 = sha256(secretC4)
   const secretHashD1 = sha256(secretD1)
+  const secretHashD2 = sha256(secretD2)
+  const secretHashD3 = sha256(secretD3)
 
-  const secrets = { secretA1, secretA2, secretB1, secretB2, secretC1, secretC2, secretD1 }
-  const secretHashes = { secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, secretHashD1 }
+  const secrets = {
+    secretA1, secretA2, secretA3, secretA4,
+    secretB1, secretB2, secretB3, secretB4,
+    secretC1, secretC2, secretC3, secretC4,
+    secretD1, secretD2, secretD3
+  }
+  const secretHashes = {
+    secretHashA1, secretHashA2, secretHashA3, secretHashA4,
+    secretHashB1, secretHashB2, secretHashB3, secretHashB4,
+    secretHashC1, secretHashC2, secretHashC3, secretHashC4,
+    secretHashD1, secretHashD2, secretHashD3
+  }
 
   return {
     secrets,


### PR DESCRIPTION
### Description

This PR modifies the BitcoinCollateralSwapProvider significantly by updating the provider to use `BitcoinJsLib` to update the tx version number as well as provide support for segwit. Currently this only works directly with a bitcoin node, however a future PR will implement (https://github.com/AtomicLoans/chainabstractionlayer-loans/issues/13). 

The previous **Swap Script** had the following form: 

```
return [
  '63', // OP_IF
    '82', // OP_SIZE
    '01', // OP_PUSHDATA(1)
    '20', // Hex 32
    '88', // OP_EQUALVERIFY
    'a8', // OP_SHA256
    '20', secretHashD1, // OP_PUSHDATA(20) {secretHash}
    '88', // OP_EQUALVERIFY
    '76', // OP_DUP
    'a9', // OP_HASH160
    '14', bidderPubKeyHash, // OP_PUSHDATA(20) {recipientPubKeyHash}
    '88', 'ac', // OP_EQUALVERIFY OP_CHECKSIG
  '67', // OP_ELSE
    '63', // OP_IF
      loanExpirationPushDataOpcode, // OP_PUSHDATA({loanExpirationHexLength})
      loanExpirationHexEncoded, // {loanExpirationHexEncoded}
      'b1', // OP_CHECKLOCKTIMEVERIFY
      '75', // OP_DROP
      '52', // PUSH #2
      borrowerPubKeyPushDataOpcode, borrowerPubKey, // OP_PUSHDATA({alicePubKeyLength}) {alicePubKey}
      lenderPubKeyPushDataOpcode, lenderPubKey, // OP_PUSHDATA({bobPubKeyLength}) {bobPubKey}
      agentPubKeyPushDataOpcode, agentPubKey, // OP_PUSHDATA({agentPubKeyLength}) {agentPubKey}
      '53', // PUSH #3
      'ae', // CHECKMULTISIG
    '67', // OP_ELSE
      biddingExpirationPushDataOpcode, // OP_PUSHDATA({biddingExpirationHexLength})
      biddingExpirationHexEncoded, // {biddingExpirationHexEncoded}
      'b1', // OP_CHECKLOCKTIMEVERIFY
      '75', // OP_DROP
      '76', 'a9', // OP_DUP OP_HASH160
      '14', borrowerPubKeyHash, // OP_PUSHDATA(20) {alicePubKeyHash}
      '88', 'ac', // OP_EQUALVERIFY OP_CHECKSIG
    '68', // OP_ENDIF
  '68' // OP_ENDIF
].join('')
```

However the issue with this script is there is nothing forcing the lender or borrower to provide a "signature back" to another p2sh. This means Alice and Dave could collude in order to steal the Bitcoin after a certain time by simply not signing the multisig and Dave could reveal secret D1 after `loanExpiration` (which should be renamed to `swapExpiration`), and also refund their stablecoin loan after `settlementExpiration` [(setex)](https://github.com/AtomicLoans/atomicloans-eth-contracts/blob/master/contracts/Sales.sol#L92). 

This PR updates the **Swap Script** to the following: 

```
OPS.OP_IF,
  OPS.OP_SIZE,
  bitcoin.script.number.encode(32),
  OPS.OP_EQUAL,
  OPS.OP_SWAP,
  OPS.OP_SHA256,
  Buffer.from(secretHashA1, 'hex'),
  OPS.OP_EQUAL,
  OPS.OP_ADD,
  OPS.OP_2,
  OPS.OP_EQUAL,
  OPS.OP_SWAP,
  OPS.OP_SIZE,
  bitcoin.script.number.encode(32),
  OPS.OP_EQUAL,
  OPS.OP_SWAP,
  OPS.OP_SHA256,
  Buffer.from(secretHashB1, 'hex'),
  OPS.OP_EQUAL,
  OPS.OP_ADD,
  OPS.OP_2,
  OPS.OP_EQUAL,
  OPS.OP_ADD,
  OPS.OP_SWAP,
  OPS.OP_SIZE,
  bitcoin.script.number.encode(32),
  OPS.OP_EQUAL,
  OPS.OP_SWAP,
  OPS.OP_SHA256,
  Buffer.from(secretHashC1, 'hex'),
  OPS.OP_EQUAL,
  OPS.OP_ADD,
  OPS.OP_2,
  OPS.OP_EQUAL,
  OPS.OP_ADD,
  OPS.OP_2,
  OPS.OP_GREATERTHANOREQUAL,
  OPS.OP_VERIFY,
  OPS.OP_SIZE,
  bitcoin.script.number.encode(32),
  OPS.OP_EQUALVERIFY,
  OPS.OP_SHA256,
  Buffer.from(secretHashD1, 'hex'),
  OPS.OP_EQUALVERIFY,
  OPS.OP_DUP,
  OPS.OP_HASH160,
  Buffer.from(borrowerPubKeyHash, 'hex'),
  OPS.OP_EQUALVERIFY,
  OPS.OP_CHECKSIG,
OPS.OP_ELSE,
  OPS.OP_IF,
    bitcoin.script.number.encode(swapExpiration),
    OPS.OP_CHECKLOCKTIMEVERIFY,
    OPS.OP_DROP,
    OPS.OP_2,
    Buffer.from(borrowerPubKey, 'hex'),
    Buffer.from(lenderPubKey, 'hex'),
    Buffer.from(agentPubKey, 'hex'),
    OPS.OP_3,
    OPS.OP_CHECKMULTISIG,
  OPS.OP_ELSE,
    bitcoin.script.number.encode(biddingExpiration),
    OPS.OP_CHECKLOCKTIMEVERIFY,
    OPS.OP_DROP,
    OPS.OP_DUP,
    OPS.OP_HASH160,
    Buffer.from(seizablePubKeyHash, 'hex'),
    OPS.OP_EQUALVERIFY,
    OPS.OP_CHECKSIG,
  OPS.OP_ENDIF,
OPS.OP_ENDIF
```

This **Swap Script** has 3 periods in it. `claimPeriod`, `liquidationPeriod` and `snatchPeriod/regainPeriod`. 

**Claim Period**: This script differs from the previous script by introducing a 2 of 3 secretHash requirement (for secretA1, secretB1, secretC1), while still requiring secretD1. This prevents Alice and Dave colluding by waiting until after `swapExpiration` and refunding both the stablecoin and taking the Bitcoin, because it requires Bob to reveal B3, which Bob would not do unless a signature was provided for `liquidationPeriod` for the multisig. 

`snatchPeriod/regainPeriod` is essentially the equivalent to `seizePeriod/refundPeriod`. However it does require a `secretA1` from Alice, because the assumption is that Alice would not sign to move the collateral if she had not taken out the loan in the first place. 

### Submission Checklist :pencil:

- [x] Update `BitcoinCollateralSwapProvider` to use `BitcoinJsLib`
- [x] Modify script to include secrets A1, B1, C1, and D1 in `swapPeriod`
- [x] Remove secrets in `biddingPeriod`
- [x] Remove `refundPeriod` since Alice would only sign if she actually took out the loan
- [x] Change `lenderPubKey` in `seizurePeriod` to either `borrowerPubKey` or `lenderPubKey` depending on if it's `seizable`
- [x] Remove `secretA1` from `seizurePeriod` since either Alice or Bob is specified as the recipient
- [x] Rename `loanExpiration` to `swapExpiration`
- [x] Update `CollateralSwap.js` in `LoanClient` interface
- [x] Add `collateralSwap.js` tests for Collateral Swap Provider
