### PR TITLE
Rename biddingExpiration to liquidationExpiration

### DIFF
--- a/test/integration/collateral/collateral.js
+++ b/test/integration/collateral/collateral.js
@@ -136,7 +136,7 @@ function testCollateral (chain) {
   })
 
   it('should allow seizure', async () => {
-    const { lockTxHash, colParams } = await lockCollateral(chain, 'biddingExpiration')
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'liquidationExpiration')
 
     const seizeParams = [lockTxHash, colParams.pubKeys, colParams.secrets.secretA1, colParams.secretHashes, colParams.expirations]
     const seizeTxHash = await chain.client.loan.collateral.seize(...seizeParams)
@@ -153,7 +153,7 @@ function testCollateral (chain) {
   })
 
   it('should fail seizing if incorrect secret provided', async () => {
-    const { lockTxHash, colParams } = await lockCollateral(chain, 'biddingExpiration')
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'liquidationExpiration')
 
     const seizeParams = [lockTxHash, colParams.pubKeys, colParams.secrets.secretB1, colParams.secretHashes, colParams.expirations]
     expect(chain.client.loan.collateral.seize(...seizeParams)).to.be.rejected

--- a/test/integration/collateral/collateralSwap.js
+++ b/test/integration/collateral/collateralSwap.js
@@ -113,7 +113,7 @@ function testCollateral (chain) {
   })
 
   it('should allow seizure', async () => {
-    const { lockTxHash, colParams } = await lockCollateral(chain, 'biddingExpiration')
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'liquidationExpiration')
 
     const seizeParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations]
     const seizeTxHash = await chain.client.loan.collateralSwap.snatch(...seizeParams)
@@ -131,7 +131,7 @@ function testCollateral (chain) {
   })
 
   it('should allow reclaiming of refundable collateral', async () => {
-    const { lockTxHash, colParams } = await lockCollateral(chain, 'biddingExpiration')
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'liquidationExpiration')
 
     const reclaimOneParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations]
     const reclaimTx = await chain.client.loan.collateralSwap.regain(...reclaimOneParams)

--- a/test/integration/collateral/liquidation.js
+++ b/test/integration/collateral/liquidation.js
@@ -218,7 +218,7 @@ function testCollateral (chain) {
 
     const curTimeExpiration = Math.floor((new Date()).getTime() / 1000) - 1000
     colParams.expirations.approveExpiration = curTimeExpiration
-    colParams.expirations.biddingExpiration = curTimeExpiration
+    colParams.expirations.liquidationExpiration = curTimeExpiration
     colParams.expirations.swapExpiration = curTimeExpiration
 
     const lockTxHash = await chain.client.loan.collateral.lock(...lockParams)

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -156,10 +156,10 @@ async function getCollateralParams (chain) {
 
   const approveExpiration     = parseInt(Date.now() / 1000) + parseInt(Math.random() * 1000000)
   const swapExpiration     = parseInt(Date.now() / 1000) + parseInt(Math.random() * 1500000)
-  const biddingExpiration  = parseInt(Date.now() / 1000) + parseInt(Math.random() * 2000000)
+  const liquidationExpiration  = parseInt(Date.now() / 1000) + parseInt(Math.random() * 2000000)
   const seizureExpiration = parseInt(Date.now() / 1000) + parseInt(Math.random() * 3000000)
 
-  const expirations = { approveExpiration, swapExpiration, biddingExpiration, seizureExpiration }
+  const expirations = { approveExpiration, swapExpiration, liquidationExpiration, seizureExpiration }
 
   return {
     values,


### PR DESCRIPTION
### Description

This PR renames `biddingExpiration` to `liquidationExpiration` to be more in line with the new implementation of the Atomic Loans ETH contracts, which will be moving away from an auction enabling individuals to bid on the collateral, and instead offer the ability of liquidators to buy the collateral at a 7% discount (https://github.com/AtomicLoans/atomicloans-eth-contracts/pull/52)

### Submission Checklist :pencil:

- [x] Rename `biddingExpiration` to `liquidationExpiration`
