### PR TITLE
Add secrets generation to LoanClient

### DIFF
--- a/packages/loan-client/lib/LoanClient.js
+++ b/packages/loan-client/lib/LoanClient.js
@@ -3,6 +3,7 @@ import debug from 'debug'
 
 import Collateral from './Collateral'
 import CollateralSwap from './CollateralSwap'
+import Secrets from './Secrets'
 
 import {
   DuplicateProviderError,
@@ -33,6 +34,7 @@ export default class LoanClient {
 
     this._collateral = new Collateral(this)
     this._collateralSwap = new CollateralSwap(this)
+    this._secrets = new Secrets(this)
   }
 
   /**
@@ -127,6 +129,10 @@ export default class LoanClient {
 
   get collateralSwap () {
     return this._collateralSwap
+  }
+
+  get secrets () {
+    return this._secrets
   }
 }
 

--- a/packages/loan-client/lib/Secrets.js
+++ b/packages/loan-client/lib/Secrets.js
@@ -1,0 +1,31 @@
+import { sha256 } from '@liquality/crypto'
+
+export default class Collateral {
+  constructor (client) {
+    this.client = client
+  }
+
+  /**
+   * Generate secrets.
+   * @param {!string} message - Message to be used for generating secret.
+   * @param {!string} address - can pass address for async claim and refunds to get deterministic secrets
+   * @return {Promise<string>} Resolves with a 32 byte secret
+   */
+  async generateSecrets (message, num = 1) {
+    const address = (await this.client.getMethod('getAddresses')())[0].address
+    let secretMessage = await this.client.getMethod('signMessage')(message, address)
+    let secrets = []
+
+     for (let i = 0; i < num; i++) {
+      secretMessage = sha256(Buffer.from(secretMessage, 'hex').reverse().toString('hex'))
+      secrets.push(sha256(secretMessage))
+    }
+
+     return secrets
+  }
+}
+
+
+
+
+  

--- a/packages/loan-client/lib/Secrets.js
+++ b/packages/loan-client/lib/Secrets.js
@@ -13,7 +13,7 @@ export default class Collateral {
    */
   async generateSecrets (message, num = 1) {
     const address = (await this.client.getMethod('getAddresses')())[0].address
-    let secretMessage = await this.client.getMethod('signMessage')(message, address)
+    let secretMessage = sha256(await this.client.getMethod('signMessage')(message, address))
     let secrets = []
 
      for (let i = 0; i < num; i++) {


### PR DESCRIPTION
### Description

This PR enables multiple secrets to be generated using one signature. To accomplish this, it first takes a signature, and then proceeds to generate both a `secretMsg` and `secret`. The `secretMsg` is calculated using the reverse `sha256` of the last `secretMsg`, and the `secret` becomes the `sha256` of the updated `secretMsg`. 

### Submission Checklist :pencil:

- [x] Add multiple secret generation
