### PR TITLE
Rename agentPubKey to arbiterPubKey

### DIFF
--- a/examples/collateral/collateralAgent.html
+++ b/examples/collateral/collateralAgent.html
@@ -32,7 +32,7 @@
         <p>seizableValue: <input type="text" id="btcSeizableValue" value="100000" /></p>
         <p>borrowerPubKey: <input type="text" id="btcBorrowerPubKey" /></p>
         <p>lenderPubKey: <input type="text" id="btcLenderPubKey" /></p>
-        <p>agentPubKey: <input type="text" id="btcAgentPubKey" /></p>
+        <p>arbiterPubKey: <input type="text" id="btcArbiterPubKey" /></p>
         <p>secretHashA1: <input type="text" id="btcSecretHashA1" /></p>
         <p>secretHashA2: <input type="text" id="btcSecretHashA2" /></p>
         <p>secretHashB1: <input type="text" id="btcSecretHashB1" /></p>
@@ -100,7 +100,7 @@ function lockCollateral (client, prefix) {
   const seizableValue = parseInt($(`#${prefix}SeizableValue`).val())
   const borrowerPubKey = $(`#${prefix}BorrowerPubKey`).val()
   const lenderPubKey = $(`#${prefix}LenderPubKey`).val()
-  const agentPubKey = $(`#${prefix}AgentPubKey`).val()
+  const arbiterPubKey = $(`#${prefix}ArbiterPubKey`).val()
   const secretHashA1 = $(`#${prefix}SecretHashA1`).val()
   const secretHashA2 = $(`#${prefix}SecretHashA2`).val()
   const secretHashB1 = $(`#${prefix}SecretHashB1`).val()
@@ -110,13 +110,13 @@ function lockCollateral (client, prefix) {
   const loanExpiration = parseInt($(`#${prefix}LoanExpiration`).val())
   const biddingExpiration = parseInt($(`#${prefix}BiddingExpiration`).val())
   const seizureExpiration = parseInt($(`#${prefix}SeizureExpiration`).val())
-  client.loan.collateralAgent.createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration).then(result => {
+  client.loan.collateralAgent.createRefundableScript(borrowerPubKey, lenderPubKey, arbiterPubKey, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration).then(result => {
     $(`#${prefix}RefundableBytecode`).text(result)
   })
-  client.loan.collateralAgent.createSeizableScript(borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
+  client.loan.collateralAgent.createSeizableScript(borrowerPubKey, lenderPubKey, arbiterPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
     $(`#${prefix}SeizableBytecode`).text(result)
   })
-  client.loan.collateralAgent.lock(refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
+  client.loan.collateralAgent.lock(refundableValue, seizableValue, borrowerPubKey, lenderPubKey, arbiterPubKey, secretHashA1, secretHashA2, secretHashB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
     $(`#${prefix}LockRefundableCollateralResult`).text(result.refundableResult)
     $(`#${prefix}LockSeizableCollateralResult`).text(result.seizableResult)
   })
@@ -124,7 +124,7 @@ function lockCollateral (client, prefix) {
 function refundCollateral (client, prefix) {
   const borrowerPubKey = $(`#${prefix}BorrowerPubKey`).val()
   const lenderPubKey = $(`#${prefix}LenderPubKey`).val()
-  const agentPubKey = $(`#${prefix}AgentPubKey`).val()
+  const arbiterPubKey = $(`#${prefix}ArbiterPubKey`).val()
   const secretHashA1 = $(`#${prefix}SecretHashA1`).val()
   const secretHashA2 = $(`#${prefix}SecretHashA2`).val()
   const secretB1 = $(`#${prefix}SecretB1`).val()
@@ -137,7 +137,7 @@ function refundCollateral (client, prefix) {
   const refundableTxHash = $(`#${prefix}LockRefundableCollateralResult`).val()
   const seizableTxHash = $(`#${prefix}LockSeizableCollateralResult`).val()
 
-  client.loan.collateralAgent.refund(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, secretB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration, true).then(result => {
+  client.loan.collateralAgent.refund(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, arbiterPubKey, secretHashA1, secretHashA2, secretB1, secretHashB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration, true).then(result => {
     $(`#${prefix}RefundRefundableCollateralResult`).text(result.refundableResult)
     $(`#${prefix}RefundSeizableCollateralResult`).text(result.seizableResult)
   })
@@ -194,7 +194,7 @@ function refundSeizableCollateral (client, prefix) {
 function multisigSignCollateral (client, prefix, isBorrower) {
   const borrowerPubKey = $(`#${prefix}BorrowerPubKey`).val()
   const lenderPubKey = $(`#${prefix}LenderPubKey`).val()
-  const agentPubKey = $(`#${prefix}AgentPubKey`).val()
+  const arbiterPubKey = $(`#${prefix}ArbiterPubKey`).val()
   const secretHashA1 = $(`#${prefix}SecretHashA1`).val()
   const secretHashA2 = $(`#${prefix}SecretHashA2`).val()
   const SecretHashB1 = $(`#${prefix}SecretHashB1`).val()
@@ -208,7 +208,7 @@ function multisigSignCollateral (client, prefix, isBorrower) {
   const seizableTxHash = $(`#${prefix}LockSeizableCollateralResult`).val()
   const to = isBorrower ? $(`#${prefix}BorrowerMultisigOutputAddress`).val() : $(`#${prefix}LenderMultisigOutputAddress`).val()
 
-  client.loan.collateralAgent.multisigSign(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretHashA2, SecretHashB1, SecretHashB2, SecretHashC1, SecretHashC2, loanExpiration, biddingExpiration, seizureExpiration, isBorrower, to).then(result => {
+  client.loan.collateralAgent.multisigSign(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, arbiterPubKey, secretHashA1, secretHashA2, SecretHashB1, SecretHashB2, SecretHashC1, SecretHashC2, loanExpiration, biddingExpiration, seizureExpiration, isBorrower, to).then(result => {
     if (isBorrower) {
       $(`#${prefix}BorrowerSignMultisigRefundableResult`).text(result.refundableSignature)
       $(`#${prefix}BorrowerSignMultisigSeizableResult`).text(result.seizableSignature)
@@ -222,7 +222,7 @@ function multisigSignCollateral (client, prefix, isBorrower) {
 function multisigSendCollateral (client, prefix) {
   const borrowerPubKey = $(`#${prefix}BorrowerPubKey`).val()
   const lenderPubKey = $(`#${prefix}LenderPubKey`).val()
-  const agentPubKey = $(`#${prefix}AgentPubKey`).val()
+  const arbiterPubKey = $(`#${prefix}ArbiterPubKey`).val()
   const secretHashA1 = $(`#${prefix}SecretHashA1`).val()
   const secretA2 = $(`#${prefix}SecretA2`).val()
   const secretHashB1 = $(`#${prefix}SecretHashB1`).val()
@@ -244,7 +244,7 @@ function multisigSendCollateral (client, prefix) {
     seizableSignature: $(`#${prefix}LenderSignMultisigSeizableResult`).val()
   }
 
-  client.loan.collateralAgent.multisigSend(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, secretHashA1, secretA2, secretHashB1, secretB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration, borrowerSignatures, lenderSignatures, to, '2').then(result => {
+  client.loan.collateralAgent.multisigSend(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, arbiterPubKey, secretHashA1, secretA2, secretHashB1, secretB2, secretHashC1, secretHashC2, loanExpiration, biddingExpiration, seizureExpiration, borrowerSignatures, lenderSignatures, to, '2').then(result => {
     $(`#${prefix}MultisigRefundableResult`).text(result.refundableResult)
     $(`#${prefix}MultisigSeizableResult`).text(result.seizableResult)
   })

--- a/examples/collateral/collateralSwap.html
+++ b/examples/collateral/collateralSwap.html
@@ -32,7 +32,7 @@
         <p>seizableValue: <input type="text" id="btcSeizableValue" value="100000" /></p>
         <p>borrowerPubKey: <input type="text" id="btcBorrowerPubKey" /></p>
         <p>lenderPubKey: <input type="text" id="btcLenderPubKey" /></p>
-        <p>agentPubKey: <input type="text" id="btcAgentPubKey" /></p>
+        <p>arbiterPubKey: <input type="text" id="btcArbiterPubKey" /></p>
         <p>recipientPubKey: <input type="text" id="btcRecipientPubKey"/></p>
         <p>recipientPubKeyHash: <input type="text" id="btcRecipientPubKeyHash"/></p>
         <p>secretHashA1: <input type="text" id="btcSecretHashA1" /></p>
@@ -103,7 +103,7 @@ function lockCollateral (client, prefix) {
   const seizableValue = parseInt($(`#${prefix}SeizableValue`).val())
   const borrowerPubKey = $(`#${prefix}BorrowerPubKey`).val()
   const lenderPubKey = $(`#${prefix}LenderPubKey`).val()
-  const agentPubKey = $(`#${prefix}AgentPubKey`).val()
+  const arbiterPubKey = $(`#${prefix}ArbiterPubKey`).val()
   const recipientPubKeyHash = $(`#${prefix}RecipientPubKeyHash`).val()
   const secretHashA1 = $(`#${prefix}SecretHashA1`).val()
   const secretHashA2 = $(`#${prefix}SecretHashA2`).val()
@@ -116,15 +116,15 @@ function lockCollateral (client, prefix) {
   const biddingExpiration = parseInt($(`#${prefix}BiddingExpiration`).val())
   const seizureExpiration = parseInt($(`#${prefix}SeizureExpiration`).val())
 
-  client.loan.collateralSwap.createRefundableScript(borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashD1, loanExpiration, biddingExpiration).then(result => {
+  client.loan.collateralSwap.createRefundableScript(borrowerPubKey, lenderPubKey, arbiterPubKey, recipientPubKeyHash, secretHashD1, loanExpiration, biddingExpiration).then(result => {
     $(`#${prefix}RefundableBytecode`).text(result)
   })
 
-  client.loan.collateralSwap.createSeizableScript(borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
+  client.loan.collateralSwap.createSeizableScript(borrowerPubKey, lenderPubKey, arbiterPubKey, recipientPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
     $(`#${prefix}SeizableBytecode`).text(result)
   })
 
-  client.loan.collateralSwap.lock(refundableValue, seizableValue, borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
+  client.loan.collateralSwap.lock(refundableValue, seizableValue, borrowerPubKey, lenderPubKey, arbiterPubKey, recipientPubKeyHash, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
     $(`#${prefix}LockRefundableCollateralResult`).text(result.refundableResult)
     $(`#${prefix}LockSeizableCollateralResult`).text(result.seizableResult)
   })
@@ -132,7 +132,7 @@ function lockCollateral (client, prefix) {
 function refundCollateral (client, prefix) {
   const borrowerPubKey = $(`#${prefix}BorrowerPubKey`).val()
   const lenderPubKey = $(`#${prefix}LenderPubKey`).val()
-  const agentPubKey = $(`#${prefix}AgentPubKey`).val()
+  const arbiterPubKey = $(`#${prefix}ArbiterPubKey`).val()
   const recipientPubKey = $(`#${prefix}RecipientPubKey`).val()
   const secretHashA1 = $(`#${prefix}SecretHashA1`).val()
   const secretHashA2 = $(`#${prefix}SecretHashA2`).val()
@@ -143,7 +143,7 @@ function refundCollateral (client, prefix) {
   const refundableTxHash = $(`#${prefix}LockRefundableCollateralResult`).val()
   const seizableTxHash = $(`#${prefix}LockSeizableCollateralResult`).val()
 
-  client.loan.collateralSwap.refund(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKey, secretHashA1, secretD1, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
+  client.loan.collateralSwap.refund(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, arbiterPubKey, recipientPubKey, secretHashA1, secretD1, loanExpiration, biddingExpiration, seizureExpiration).then(result => {
     $(`#${prefix}RefundRefundableCollateralResult`).text(result.refundableResult)
     $(`#${prefix}RefundSeizableCollateralResult`).text(result.seizableResult)
   })
@@ -200,7 +200,7 @@ function refundSeizableCollateral (client, prefix) {
 function multisigSignCollateral (client, prefix, isBorrower) {
   const borrowerPubKey = $(`#${prefix}BorrowerPubKey`).val()
   const lenderPubKey = $(`#${prefix}LenderPubKey`).val()
-  const agentPubKey = $(`#${prefix}AgentPubKey`).val()
+  const arbiterPubKey = $(`#${prefix}ArbiterPubKey`).val()
   const recipientPubKey = $(`#${prefix}RecipientPubKey`).val()
   const secretHashA1 = $(`#${prefix}SecretHashA1`).val()
   const secretHashA2 = $(`#${prefix}SecretHashA2`).val()
@@ -216,7 +216,7 @@ function multisigSignCollateral (client, prefix, isBorrower) {
   const seizableTxHash = $(`#${prefix}LockSeizableCollateralResult`).val()
   const to = isBorrower ? $(`#${prefix}BorrowerMultisigOutputAddress`).val() : $(`#${prefix}LenderMultisigOutputAddress`).val()
 
-  client.loan.collateralSwap.multisigSign(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, isBorrower, to).then(result => {
+  client.loan.collateralSwap.multisigSign(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, arbiterPubKey, recipientPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, isBorrower, to).then(result => {
     if (isBorrower) {
       $(`#${prefix}BorrowerSignMultisigRefundableResult`).text(result.refundableSignature)
       $(`#${prefix}BorrowerSignMultisigSeizableResult`).text(result.seizableSignature)
@@ -230,7 +230,7 @@ function multisigSignCollateral (client, prefix, isBorrower) {
 function multisigSendCollateral (client, prefix) {
   const borrowerPubKey = $(`#${prefix}BorrowerPubKey`).val()
   const lenderPubKey = $(`#${prefix}LenderPubKey`).val()
-  const agentPubKey = $(`#${prefix}AgentPubKey`).val()
+  const arbiterPubKey = $(`#${prefix}ArbiterPubKey`).val()
   const recipientPubKey = $(`#${prefix}RecipientPubKey`).val()
   const secretHashA1 = $(`#${prefix}SecretHashA1`).val()
   const secretA2 = $(`#${prefix}SecretA2`).val()
@@ -256,7 +256,7 @@ function multisigSendCollateral (client, prefix) {
 
   debugger
 
-  client.loan.collateralSwap.multisigSend(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, agentPubKey, recipientPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, borrowerSignatures, lenderSignatures, to).then(result => {
+  client.loan.collateralSwap.multisigSend(refundableTxHash, seizableTxHash, borrowerPubKey, lenderPubKey, arbiterPubKey, recipientPubKey, secretHashA1, secretHashD1, loanExpiration, biddingExpiration, seizureExpiration, borrowerSignatures, lenderSignatures, to).then(result => {
     $(`#${prefix}MultisigRefundableResult`).text(result.refundableResult)
     $(`#${prefix}MultisigSeizableResult`).text(result.seizableResult)
   })

--- a/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
+++ b/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
@@ -59,7 +59,7 @@ export default class BitcoinCollateralProvider extends Provider {
   }
 
   getCollateralOutput (pubKeys, secretHashes, expirations, seizable) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey }            = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey }            = pubKeys
     const { secretHashA1 }                                         = secretHashes
     const { secretHashB1 }                                         = secretHashes
     const { secretHashC1 }                                         = secretHashes
@@ -110,7 +110,7 @@ export default class BitcoinCollateralProvider extends Provider {
           OPS.OP_2,
           Buffer.from(borrowerPubKey, 'hex'),
           Buffer.from(lenderPubKey, 'hex'),
-          Buffer.from(agentPubKey, 'hex'),
+          Buffer.from(arbiterPubKey, 'hex'),
           OPS.OP_3,
           OPS.OP_CHECKMULTISIG,
         OPS.OP_ELSE,
@@ -251,7 +251,7 @@ export default class BitcoinCollateralProvider extends Provider {
   }
 
   async _refundOne (initiationTxHash, pubKeys, secrets, secretHashes, expirations, period, seizable) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const network = this._bitcoinJsNetwork
     const pubKey = (period === 'seizurePeriod') ? lenderPubKey : borrowerPubKey
     const address = this.pubKeyToAddress(Buffer.from(pubKey, 'hex'))
@@ -280,7 +280,7 @@ export default class BitcoinCollateralProvider extends Provider {
   }
 
   async _refundAll (initiationTxHash, pubKeys, secrets, secretHashes, expirations, period) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const network = this._bitcoinJsNetwork
     const pubKey = (period === 'seizurePeriod') ? lenderPubKey : borrowerPubKey
     const address = this.pubKeyToAddress(Buffer.from(pubKey, 'hex'))
@@ -320,12 +320,12 @@ export default class BitcoinCollateralProvider extends Provider {
   }
 
   async _multisigSign (initiationTxHash, pubKeys, secretHashes, expirations, party, outputs) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const { approveExpiration, liquidationExpiration, seizureExpiration } = expirations
     const period = 'liquidationPeriod'
     const network = this._bitcoinJsNetwork
 
-    const pubKey = party === 'lender' ? lenderPubKey : party === 'borrower' ? borrowerPubKey : agentPubKey
+    const pubKey = party === 'lender' ? lenderPubKey : party === 'borrower' ? borrowerPubKey : arbiterPubKey
     const address = this.pubKeyToAddress(Buffer.from(pubKey, 'hex'))
 
     const initiationTxRaw = await this.getMethod('getRawTransactionByHash')(initiationTxHash)
@@ -355,7 +355,7 @@ export default class BitcoinCollateralProvider extends Provider {
   }
 
   async _multisigSend (initiationTxHash, sigs, pubKeys, secretHashes, expirations, outputs) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const period = 'liquidationPeriod'
     const network = this._bitcoinJsNetwork
 

--- a/packages/bitcoin-collateral-swap-provider/lib/BitcoinCollateralSwapProvider.js
+++ b/packages/bitcoin-collateral-swap-provider/lib/BitcoinCollateralSwapProvider.js
@@ -57,7 +57,7 @@ export default class BitcoinCollateralSwapProvider extends Provider {
   }
 
   getCollateralOutput (pubKeys, secretHashes, expirations, seizable) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const { liquidatorPubKeyHash }                      = pubKeys
     const { secretHashA1 }                              = secretHashes
     const { secretHashB1 }                              = secretHashes
@@ -128,7 +128,7 @@ export default class BitcoinCollateralSwapProvider extends Provider {
           OPS.OP_2,
           Buffer.from(borrowerPubKey, 'hex'),
           Buffer.from(lenderPubKey, 'hex'),
-          Buffer.from(agentPubKey, 'hex'),
+          Buffer.from(arbiterPubKey, 'hex'),
           OPS.OP_3,
           OPS.OP_CHECKMULTISIG,
         OPS.OP_ELSE,
@@ -248,7 +248,7 @@ export default class BitcoinCollateralSwapProvider extends Provider {
   }
 
   async _refundOne (initiationTxHash, pubKeys, secretHashes, expirations, period, seizable) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const network = this._bitcoinJsNetwork
     const pubKey = seizable ? lenderPubKey : borrowerPubKey
     const address = this.pubKeyToAddress(Buffer.from(pubKey, 'hex'))
@@ -279,7 +279,7 @@ export default class BitcoinCollateralSwapProvider extends Provider {
   }
 
   async _refundAll (initiationTxHash, pubKeys, secrets, secretHashes, expirations, period) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey, liquidatorPubKey } = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey, liquidatorPubKey } = pubKeys
     const network = this._bitcoinJsNetwork
     const pubKey = (period === 'claimPeriod') ? liquidatorPubKey : (period === 'seizurePeriod') ? lenderPubKey : borrowerPubKey
     const address = this.pubKeyToAddress(Buffer.from(pubKey, 'hex'))
@@ -322,11 +322,11 @@ export default class BitcoinCollateralSwapProvider extends Provider {
   }
 
   async _multisigWrite (initiationTxHash, pubKeys, secretHashes, expirations, party, to) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const period = 'liquidationPeriod'
     const network = this._bitcoinJsNetwork
 
-    const pubKey = party === 'lender' ? lenderPubKey : party === 'borrower' ? borrowerPubKey : agentPubKey
+    const pubKey = party === 'lender' ? lenderPubKey : party === 'borrower' ? borrowerPubKey : arbiterPubKey
     const address = this.pubKeyToAddress(Buffer.from(pubKey, 'hex'))
 
     const initiationTxRaw = await this.getMethod('getRawTransactionByHash')(initiationTxHash)
@@ -356,7 +356,7 @@ export default class BitcoinCollateralSwapProvider extends Provider {
   }
 
   async _multisigMove (initiationTxHash, sigs, pubKeys, secretHashes, expirations, to) {
-    const { borrowerPubKey, lenderPubKey, agentPubKey } = pubKeys
+    const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const period = 'liquidationPeriod'
     const network = this._bitcoinJsNetwork
 

--- a/test/integration/common.js
+++ b/test/integration/common.js
@@ -159,9 +159,9 @@ async function getCollateralParams (chain) {
   const lenderAddress = lenderPubKeyAndAddress.address
   const lenderPubKey = lenderPubKeyAndAddress.pubKey
 
-  const agentPubKeyAndAddress = await getUnusedPubKeyAndAddress(chain)
-  const agentAddress = agentPubKeyAndAddress.address
-  const agentPubKey = agentPubKeyAndAddress.pubKey
+  const arbiterPubKeyAndAddress = await getUnusedPubKeyAndAddress(chain)
+  const agentAddress = arbiterPubKeyAndAddress.address
+  const arbiterPubKey = arbiterPubKeyAndAddress.pubKey
 
   const liquidatorPubKeyAndAddress = await getUnusedPubKeyAndAddress(chain)
   const liquidatorAddress = liquidatorPubKeyAndAddress.address
@@ -169,7 +169,7 @@ async function getCollateralParams (chain) {
   const liquidatorPubKeyHash = hash160(liquidatorPubKey)
 
   const addresses = { borrowerAddress, lenderAddress, agentAddress, liquidatorAddress }
-  const pubKeys = { borrowerPubKey, lenderPubKey, agentPubKey, liquidatorPubKeyHash, liquidatorPubKey }
+  const pubKeys = { borrowerPubKey, lenderPubKey, arbiterPubKey, liquidatorPubKeyHash, liquidatorPubKey }
 
   const { secrets, secretHashes } = await getCollateralSecretParams(chain)
 


### PR DESCRIPTION
### Description

This PR renames `agentPubKey` to `arbiterPubKey` to be inline with https://github.com/AtomicLoans/atomicloans-eth-contracts

### Submission Checklist :pencil:

- [x] Rename `agentPubKey` to `arbiterPubKey`
