### PR TITLE
Add multisigBuild and multisigMake

### DIFF
--- a/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
+++ b/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
@@ -231,8 +231,13 @@ export default class BitcoinCollateralProvider extends Provider {
     return this._multisigSign(txHash, pubKeys, secretHashes, expirations, party, outputs)
   }
 
+  async multisigBuild (txHash, sigs, pubKeys, secretHashes, expirations, outputs) {
+    return this._multisigBuild(txHash, sigs, pubKeys, secretHashes, expirations, outputs)
+  }
+
   async multisigSend (txHash, sigs, pubKeys, secretHashes, expirations, outputs) {
-    return this._multisigSend(txHash, sigs, pubKeys, secretHashes, expirations, outputs)
+    const txHex = await this._multisigBuild(txHash, sigs, pubKeys, secretHashes, expirations, outputs)
+    return this.getMethod('sendRawTransaction')(txHex)
   }
 
   async seize (txHash, pubKeys, secret, secretHashes, expirations) {
@@ -354,7 +359,7 @@ export default class BitcoinCollateralProvider extends Provider {
     return this.createSigs(initiationTxRaw, tx, address, ref, sei, expirations, period)
   }
 
-  async _multisigSend (initiationTxHash, sigs, pubKeys, secretHashes, expirations, outputs) {
+  async _multisigBuild (initiationTxHash, sigs, pubKeys, secretHashes, expirations, outputs) {
     const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const period = 'liquidationPeriod'
     const network = this._bitcoinJsNetwork
@@ -388,7 +393,7 @@ export default class BitcoinCollateralProvider extends Provider {
     this.finalizeTx(tx, ref, 0)
     this.finalizeTx(tx, sei, 1)
 
-    return this.getMethod('sendRawTransaction')(tx.toHex())
+    return tx.toHex()
   }
 
   setPaymentVariants (initiationTx, col) {

--- a/packages/bitcoin-collateral-swap-provider/lib/BitcoinCollateralSwapProvider.js
+++ b/packages/bitcoin-collateral-swap-provider/lib/BitcoinCollateralSwapProvider.js
@@ -235,8 +235,13 @@ export default class BitcoinCollateralSwapProvider extends Provider {
     return this._multisigWrite(txHash, pubKeys, secretHashes, expirations, party, to)
   }
 
+  async multisigMake (txHash, sigs, pubKeys, secretHashes, expirations, to) {
+    return this._multisigMake(txHash, sigs, pubKeys, secretHashes, expirations, to)
+  }
+
   async multisigMove (txHash, sigs, pubKeys, secretHashes, expirations, to) {
-    return this._multisigMove(txHash, sigs, pubKeys, secretHashes, expirations, to)
+    const txHex = await this._multisigMake(txHash, sigs, pubKeys, secretHashes, expirations, to)
+    return this.getMethod('sendRawTransaction')(txHex)
   }
 
   async snatch (txHash, pubKeys, secretHashes, expirations) {
@@ -355,7 +360,7 @@ export default class BitcoinCollateralSwapProvider extends Provider {
     return this.createSigs(initiationTxRaw, tx, address, ref, sei, expirations, period)
   }
 
-  async _multisigMove (initiationTxHash, sigs, pubKeys, secretHashes, expirations, to) {
+  async _multisigMake (initiationTxHash, sigs, pubKeys, secretHashes, expirations, to) {
     const { borrowerPubKey, lenderPubKey, arbiterPubKey } = pubKeys
     const period = 'liquidationPeriod'
     const network = this._bitcoinJsNetwork
@@ -389,7 +394,7 @@ export default class BitcoinCollateralSwapProvider extends Provider {
     this.finalizeTx(tx, ref, 0)
     this.finalizeTx(tx, sei, 1)
 
-    return this.getMethod('sendRawTransaction')(tx.toHex())
+    return tx.toHex()
   }
 
   setPaymentVariants (initiationTx, col) {

--- a/packages/loan-client/lib/Collateral.js
+++ b/packages/loan-client/lib/Collateral.js
@@ -23,6 +23,10 @@ export default class Collateral {
     return this.client.getMethod('multisigSign')(txHash, pubKeys, secretHashes, expirations, party, to)
   }
 
+  async multisigBuild (txHash, sigs, pubKeys, secrets, secretHashes, expirations, to) {
+    return this.client.getMethod('multisigBuild')(txHash, sigs, pubKeys, secrets, secretHashes, expirations, to)
+  }
+
   async multisigSend (txHash, sigs, pubKeys, secrets, secretHashes, expirations, to) {
     return this.client.getMethod('multisigSend')(txHash, sigs, pubKeys, secrets, secretHashes, expirations, to)
   }

--- a/packages/loan-client/lib/CollateralSwap.js
+++ b/packages/loan-client/lib/CollateralSwap.js
@@ -19,6 +19,10 @@ export default class CollateralSwap {
     return this.client.getMethod('multisigWrite')(txHash, pubKeys, secretHashes, expirations, party, to)
   }
 
+  async multisigMake (txHash, sigs, pubKeys, secrets, secretHashes, expirations, to) {
+    return this.client.getMethod('multisigMake')(txHash, sigs, pubKeys, secrets, secretHashes, expirations, to)
+  }
+
   async multisigMove (txHash, sigs, pubKeys, secrets, secretHashes, expirations, to) {
     return this.client.getMethod('multisigMove')(txHash, sigs, pubKeys, secrets, secretHashes, expirations, to)
   }

--- a/test/integration/collateral/collateral.js
+++ b/test/integration/collateral/collateral.js
@@ -76,6 +76,32 @@ function testCollateral (chain) {
     expect(71 <= Buffer.from(seizableSig, 'hex').length <= 72).to.equal(true)
   })
 
+  it('should allow multisig building', async () => {
+    const { lockTxHash, colParams } = await lockCollateral(chain, 'approveExpiration')
+
+    const { address: to } = await chain.client.getMethod('getUnusedAddress')()
+
+    const multisigBorrowerParams = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'borrower', to]
+    const borrowerSigs = await chain.client.loan.collateral.multisigSign(...multisigBorrowerParams)
+
+    const multisigParamsLender = [lockTxHash, colParams.pubKeys, colParams.secretHashes, colParams.expirations, 'lender', to]
+    const lenderSigs = await chain.client.loan.collateral.multisigSign(...multisigParamsLender)
+
+    const sigs = {
+      refundable: [Buffer.from(borrowerSigs.refundableSig, 'hex'), Buffer.from(lenderSigs.refundableSig, 'hex')],
+      seizable: [Buffer.from(borrowerSigs.seizableSig, 'hex'), Buffer.from(lenderSigs.seizableSig, 'hex')]
+    }
+
+    const multisigSendTxRaw = await chain.client.loan.collateral.multisigBuild(lockTxHash, sigs, colParams.pubKeys, colParams.secretHashes, colParams.expirations, to)
+    const multisigSendTx = await chain.client.getMethod('decodeRawTransaction')(multisigSendTxRaw)
+
+    const multisigSendVouts = multisigSendTx._raw.data.vout
+    const multisigSendVins = multisigSendTx._raw.data.vin
+
+    expect(multisigSendVins.length).to.equal(2)
+    expect(multisigSendVouts.length).to.equal(1)
+  })
+
   it('should allow multisig signing and sending', async () => {
     const { lockTxHash, colParams } = await lockCollateral(chain, 'approveExpiration')
 


### PR DESCRIPTION
### Description

This PR adds `multisigBuild` to `BitcoinCollateralProvider` and `multisigMake` to `BitcoinCollateralSwapProvider`. This enables anyone using these providers to build the transaction before actually sending it. This can be useful, for calculating the fees of the refundable and seizable collateral before passing it onto to the second party to sign the multisig. 

### Submission Checklist :pencil:

- [x] Add `multisigBuild` to `BitcoinCollateralProvider`
- [x] Add `multisigMake` to `BitcoinCollateralSwapProvider`
