### PR TITLE
Add additional collateral locking options

### DIFF
--- a/packages/loan-client/lib/Collateral.js
+++ b/packages/loan-client/lib/Collateral.js
@@ -11,12 +11,28 @@ export default class Collateral {
     return this.client.getMethod('lock')(values, pubKeys, secretHashes, expirations)
   }
 
+  async lockRefundable (value, pubKeys, secretHashes, expirations) {
+    return this.client.getMethod('lockRefundable')(value, pubKeys, secretHashes, expirations)
+  }
+
+  async lockSeizable (value, pubKeys, secretHashes, expirations) {
+    return this.client.getMethod('lockSeizable')(value, pubKeys, secretHashes, expirations)
+  }
+
   async getLockAddresses (pubKeys, secretHashes, expirations) {
     return this.client.getMethod('getLockAddresses')(pubKeys, secretHashes, expirations)
   }
 
   async refund (txHashes, pubKeys, secret, secretHashes, expirations) {
     return this.client.getMethod('refund')(txHashes, pubKeys, secret, secretHashes, expirations)
+  }
+
+  async refundRefundable (txHashes, pubKeys, secret, secretHashes, expirations) {
+    return this.client.getMethod('refundRefundable')(txHashes, pubKeys, secret, secretHashes, expirations)
+  }
+
+  async refundSeizable (txHashes, pubKeys, secret, secretHashes, expirations) {
+    return this.client.getMethod('refundSeizable')(txHashes, pubKeys, secret, secretHashes, expirations)
   }
 
   async multisigSign (txHash, pubKeys, secretHashes, expirations, party, to) {


### PR DESCRIPTION
### Description

This PR adds additional locking functions for locking collateral by individual `refundable` or `seizable` amounts. 

### Submission Checklist :pencil:

- [x] Add `lockRefundable` to `BitcoinCollateralProvider`
- [x] Add `lockSeizable` to `BitcoinCollateralProvider`
- [x] Add `refundRefundable` to `BitcoinCollateralProvider`
- [x] Add `refundSeizable` to `BitcoinCollateralProvider`
