### PR TITLE
Add multisig sign, build, and send many

### DIFF
--- a/packages/loan-client/lib/Collateral.js
+++ b/packages/loan-client/lib/Collateral.js
@@ -51,6 +51,18 @@ export default class Collateral {
     return this.client.getMethod('multisigSend')(txHash, sigs, pubKeys, secrets, secretHashes, expirations, to)
   }
 
+  async multisigSignMany (txHashes, pubKeys, secretHashes, expirations, party, outputs) {
+    return this.client.getMethod('multisigSignMany')(txHashes, pubKeys, secretHashes, expirations, party, outputs)
+  }
+
+  async multisigBuildMany (txHashes, sigs, pubKeys, secretHashes, expirations, outputs) {
+    return this.client.getMethod('multisigBuildMany')(txHashes, sigs, pubKeys, secretHashes, expirations, outputs)
+  }
+
+  async multisigSendMany (txHashes, sigs, pubKeys, secretHashes, expirations, outputs) {
+    return this.client.getMethod('multisigSendMany')(txHashes, sigs, pubKeys, secretHashes, expirations, outputs)
+  }
+
   async seize (txHash, pubKeys, secret, secretHashes, expirations) {
     return this.client.getMethod('seize')(txHash, pubKeys, secret, secretHashes, expirations)
   }

--- a/packages/loan-client/test/unit/LoanClient.test.js
+++ b/packages/loan-client/test/unit/LoanClient.test.js
@@ -35,5 +35,53 @@ describe('Client methods without providers', () => {
     it('should throw NoProviderError', async () => {
       return expect(client.collateral.refund(1)).to.be.rejectedWith(/No provider provided/)
     })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.refundRefundable(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.refundSeizable(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.refundMany(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.multisigSign(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.multisigBuild(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.multisigSend(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.multisigSignMany(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.multisigBuildMany(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.multisigSendMany(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.seize(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.reclaimOne(1)).to.be.rejectedWith(/No provider provided/)
+    })
+
+    it('should throw NoProviderError', async () => {
+      return expect(client.collateral.reclaimAll(1)).to.be.rejectedWith(/No provider provided/)
+    })
   })
 })


### PR DESCRIPTION
### Description

This PR adds `multisigSignMany`, `multisigBuildMany`,  and `multisigSendMany` which allows users to unlock and move collateral using the 2-of-3 multisig with multiple collateral refundable and seizable utxos. 

### Submission Checklist :pencil:

- [x] Add `multisigSignMany` to `BitcoinCollateralProvider`
- [x] Add `multisigBuildMany` to `BitcoinCollateralProvider`
- [x] Add `multisigSendMany` to `BitcoinCollateralProvider`
