### PR TITLE
QSP-11 Ensure that if colVout is undefined there is an exception thrown

### DIFF
--- a/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
+++ b/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
@@ -728,6 +728,7 @@ export default class BitcoinCollateralProvider extends Provider {
         col.colVout = vout
       }
     }
+    if (col.colVout === undefined) { throw new Error('Could not find transaction based on redeem script') }
   }
 
   buildColTx (period, col, expirations, to) {

--- a/packages/bitcoin-collateral-provider/test/unit/BitcoinCollateralProvider.test.js
+++ b/packages/bitcoin-collateral-provider/test/unit/BitcoinCollateralProvider.test.js
@@ -1,0 +1,28 @@
+/* eslint-env mocha */
+
+import BitcoinCollateralProvider from '../../lib'
+
+const { expect } = require('chai').use(require('chai-as-promised'))
+
+describe('Client methods without providers', () => {
+  let btcCollateralProvider
+
+  beforeEach(() => {
+    btcCollateralProvider = new BitcoinCollateralProvider()
+  })
+
+  describe('setPaymentVariants', () => {
+    it('should throw if colVout undefined', async () => {
+      const initiationTx = {
+        _raw: {
+          data: {
+            vout: []
+          }
+        }
+      }
+      const col = {}
+
+      expect(function() { btcCollateralProvider.setPaymentVariants(initiationTx, col) }).to.throw(Error)
+    })
+  })
+})

--- a/test/integration/collateral/collateral.js
+++ b/test/integration/collateral/collateral.js
@@ -309,7 +309,7 @@ function testCollateral (chain) {
     expect(multisigSendManyVouts.length).to.equal(1)
   })
 
-  it.only('should allow multisig signing and sending for all collateral after locking multiple times', async () => {
+  it('should allow multisig signing and sending for all collateral after locking multiple times', async () => {
     let colParams = await getCollateralParams(chain)
     const lockParams = [colParams.values, colParams.pubKeys, colParams.secretHashes, colParams.expirations]
     const lockTxHash = await chain.client.loan.collateral.lock(...lockParams)


### PR DESCRIPTION
### Description

This PR ensures that an exception is thrown if `colVout` is undefined in `BitcoinCollateralProvider.setPaymentVariants`

### Submission Checklist :pencil:

- [x] Add exception when `colVout` is undefined in `BitcoinCollateralProvider.setPaymentVariants`