### PR TITLE
QSP-6 Undocumented Magic Constants

### DIFF
--- a/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
+++ b/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
@@ -749,7 +749,11 @@ export default class BitcoinCollateralProvider extends Provider {
 
     // TODO: Implement proper fee calculation that counts bytes in inputs and outputs
     // TODO: use node's feePerByte
-    const txfee = calculateFee(6, 6, 14)
+    const numInputs = 1
+    const numOutputs = 1
+    const feePerByte = 42 // Note: feePerByte is extremely high because inputs bytes is based on 148 bytes, which is incorrect for this redeem script
+
+    const txfee = calculateFee(numInputs, numOutputs, feePerByte) // 7644 satoshis
 
     txb.addInput(col.colVout.txid, col.colVout.n, 0, col.prevOutScript)
     txb.addOutput(addressToString(to), col.colVout.vSat - txfee)
@@ -786,7 +790,10 @@ export default class BitcoinCollateralProvider extends Provider {
       const feePerByte = Math.ceil(await this.getMethod('getFeePerByte')())
       txfee = BigNumber(feePerByte).times(364).toNumber()
     } else {
-      txfee = calculateFee(6, 6, 14)
+      const numInputs = 2
+      const numOutputs = 2
+      const feePerByte = 42 // Note: feePerByte is extremely high because inputs bytes is based on 148 bytes, which is incorrect for this redeem script
+      txfee = calculateFee(numInputs, numOutputs, feePerByte) // 15288 satoshis
     }
 
     txb.addInput(ref.colVout.txid, ref.colVout.n, 0, ref.prevOutScript)

--- a/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
+++ b/packages/bitcoin-collateral-provider/lib/BitcoinCollateralProvider.js
@@ -800,7 +800,7 @@ export default class BitcoinCollateralProvider extends Provider {
     txb.addInput(sei.colVout.txid, sei.colVout.n, 0, sei.prevOutScript)
 
     if (outputs.length === 1) {
-      txb.addOutput(addressToString(outputs[0].address), ref.colVout.vSat.plus(sei.colVout.vSat) - txfee)
+      txb.addOutput(addressToString(outputs[0].address), BigNumber(ref.colVout.vSat).plus(sei.colVout.vSat).minus(txfee).toNumber())
     } else if (outputs.length === 2) {
       txb.addOutput(addressToString(outputs[0].address), outputs[0].value === undefined ? ref.colVout.vSat - (txfee / 2) : outputs[0].value)
       txb.addOutput(addressToString(outputs[1].address), outputs[1].value === undefined ? sei.colVout.vSat - (txfee / 2) : outputs[1].value)

--- a/packages/bitcoin-collateral-provider/test/unit/BitcoinCollateralProvider.test.js
+++ b/packages/bitcoin-collateral-provider/test/unit/BitcoinCollateralProvider.test.js
@@ -2,13 +2,20 @@
 
 import BitcoinCollateralProvider from '../../lib'
 
+import * as bitcoin from 'bitcoinjs-lib'
+import { providers } from '@liquality/bundle'
+import { BigNumber } from 'bignumber.js'
+
 const { expect } = require('chai').use(require('chai-as-promised'))
+
+const bitcoinNetworks = providers.bitcoin.networks
+const bitcoinNetwork = bitcoinNetworks['bitcoin_regtest']
 
 describe('Client methods without providers', () => {
   let btcCollateralProvider
 
   beforeEach(() => {
-    btcCollateralProvider = new BitcoinCollateralProvider()
+    btcCollateralProvider = new BitcoinCollateralProvider({ network: bitcoinNetwork })
   })
 
   describe('setPaymentVariants', () => {
@@ -23,6 +30,51 @@ describe('Client methods without providers', () => {
       const col = {}
 
       expect(function() { btcCollateralProvider.setPaymentVariants(initiationTx, col) }).to.throw(Error)
+    })
+  })
+
+  describe('buildFullColTx', () => {
+    it('should create tx with default fee value if estimateFees is false', async () => {
+      const currentTime = Math.floor(new Date().getTime() / 1000)
+
+      let period = 'liquidationPeriod'
+      let ref = {
+        colVout: {
+          value: 0.005,
+          n: 0,
+          txid: 'e76641fb8659f2633bf6ac8448934d96c267c845f8155643749cfcb24131e694'
+        },
+        paymentVariant: {
+          output: Buffer.from('0020e66de259eec27e41ba442095670956da14e69c8161886a61086b70ce4f5cc0d0', 'hex')
+        },
+        paymentVariantName: 'p2wsh'
+      }
+      let sei = {
+        colVout: {
+          value: 0.01,
+          n: 1,
+          txid: 'e76641fb8659f2633bf6ac8448934d96c267c845f8155643749cfcb24131e694'
+        },
+        paymentVariant: {
+          output: Buffer.from('00208f10f15e2eef5954b089d4bb2702bea924e66f6d69ba37513e79fec1ba05f7e2', 'hex')
+        },
+        paymentVariantName: 'p2wsh'
+      }
+      let expirations = { approveExpiration: 1581302782, swapExpiration: 1581848973, liquidationExpiration: 1581993054, seizureExpiration: 1581992417 }
+      let outputs = 'bcrt1qgn9qdjtl9v8ytny77lpwnd6j7um73dugylmcwf'
+      let estimateFees = false
+
+      const defaultFeeValue = 15708
+
+      const expectedInputValue = BigNumber(BigNumber(ref.colVout.value).times(1e8)).plus(BigNumber(sei.colVout.value).times(1e8)).toNumber()
+      const expectedOutputValue = BigNumber(expectedInputValue).minus(defaultFeeValue).toNumber()
+
+      const txb = await btcCollateralProvider.buildFullColTx(period, ref, sei, expirations, outputs, estimateFees)
+
+      const { outs } = txb
+
+      const output = outs[0]
+      expect(output.value).to.equal(expectedOutputValue)
     })
   })
 })


### PR DESCRIPTION
### Description

This PR adds proper naming of constants used in `calculateFee` in `BitcoinCollateralProvider`

### Submission Checklist :pencil:

- [x] Add documentation for constants used in `calculateFee` in `BitcoinCollateralProvider`
